### PR TITLE
2024 04 11 new model

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,10 @@ We have the following API to read in the optimized grasps from above:
 ```
 def get_sorted_grasps_from_file(
     optimized_grasp_config_dict_filepath: pathlib.Path,
-    object_transform_world_frame: Optional[np.ndarray] = None,
     error_if_no_loss: bool = True,
     check: bool = True,
     print_best: bool = True,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     This function processes optimized grasping configurations in preparation for hardware tests.
 
@@ -117,33 +116,28 @@ def get_sorted_grasps_from_file(
 
     Parameters:
     optimized_grasp_config_dict_filepath (pathlib.Path): The file path to the optimized grasp .npy file. This file should contain wrist poses, joint angles, grasp orientations, and loss from grasp metric.
-    object_transform_world_frame (np.ndarray): Transformation matrix representing the object's pose in world frame. Defaults to None.
     error_if_no_loss (bool): Whether to raise an error if the loss is not found in the grasp config dict. Defaults to True.
     check (bool): Whether to check the validity of the grasp configurations (sometimes sensitive or off manifold from optimization?). Defaults to True.
     print_best (bool): Whether to print the best grasp configurations. Defaults to True.
 
     Returns:
-    Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    - A batch of wrist translations in a numpy array of shape (B, 3), representing position in world frame
-    - A batch of wrist rotations in a numpy array of shape (B, 3, 3), representing orientation in world frame (avoid quat to be less ambiguous about order)
+    Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    - A batch of wrist transformations of object yup frame wrt nerf frame in a numpy array of shape (B, 4, 4), representing pose in nerf frame (avoid quat to be less ambiguous about order)
     - A batch of joint angles in a numpy array of shape (B, 16)
     - A batch of target joint angles in a numpy array of shape (B, 16)
 
     Example:
-    >>> wrist_trans, wrist_rot, joint_angles, target_joint_angles = get_sorted_grasps(pathlib.Path("path/to/optimized_grasp_config.npy"))
-    >>> B = wrist_trans.shape[0]
-    >>> assert wrist_trans.shape == (B, 3)
-    >>> assert wrist_rot.shape == (B, 3, 3)
-    >>> assert joint_angles.shape == (B, 16)
-    >>> assert target_joint_angles.shape == (B, 16)
+    >>> X_Oy_H_array, joint_angles_array, target_joint_angles_array = get_sorted_grasps_from_file(pathlib.Path("path/to/optimized_grasp_config.npy"))
+    >>> B = X_Oy_H_array.shape[0]
+    >>> assert X_Oy_H_array.shape == (B, 4, 4)
+    >>> assert joint_angles_array.shape == (B, 16)
+    >>> assert target_joint_angles_array.shape == (B, 16)
     """
 ```
 
-This can be imported with `from nerf_grasping.optimizer_utils import get_sorted_grasps`.
+This can be imported with `from nerf_grasping.optimizer_utils import get_sorted_grasps_from_file`.
 
-Start from the beginning of the list. Check if the grasp passes collision checks. If it does, execute the grasp. If it does not, move onto the next grasp.
-
-`object_transform_world_frame` is a transformation matrix that represents the pose of the object center in world frame, which helps move the grasp from object frame to world frame.
+Start from the beginning of the batch dimension. Check if the grasp passes collision checks. If it does, execute the grasp. If it does not, move onto the next grasp.
 
 # How to run (2023-12-04)
 

--- a/TYLER_SCRATCH_11_supervised_learning.py
+++ b/TYLER_SCRATCH_11_supervised_learning.py
@@ -1,0 +1,411 @@
+# %%
+import torch
+import pathlib
+import numpy as np
+
+# from tqdm import tqdm
+from tqdm.notebook import tqdm
+from localscope import localscope
+from typing import List, Tuple
+from dataclasses import dataclass, field
+import matplotlib.pyplot as plt
+
+
+# %%
+@dataclass
+class Config:
+    grasp_config_dicts_folder: pathlib.Path = pathlib.Path(
+        "/juno/u/tylerlum/github_repos/nerf_grasping/data/2024-03-10_75bottle_augmented_pose_HALTON_400/evaled_grasp_config_dicts_train/"
+    )
+    batch_size: int = 256
+    n_epochs: int = 100
+    hidden_size: List[int] = field(
+        default_factory=lambda: [512, 512]
+    )
+
+
+# %%
+cfg = Config()
+assert cfg.grasp_config_dicts_folder.exists()
+grasp_config_dict_paths = sorted(list(cfg.grasp_config_dicts_folder.glob("*.npy")))
+assert len(grasp_config_dict_paths) > 0
+print(f"len(grasp_config_dict_paths): {len(grasp_config_dict_paths)}")
+
+# %%
+N_OBJECTS = len(grasp_config_dict_paths)
+grasp_config_dicts = [
+    np.load(grasp_config_dict_path, allow_pickle=True).item()
+    for grasp_config_dict_path in grasp_config_dict_paths
+]
+n_grasps_per_object_list = [
+    len(gc_dict["passed_eval"]) for gc_dict in grasp_config_dicts
+]
+n_grasps_per_object = n_grasps_per_object_list[0]
+assert all(n_grasps_per_object == n_grasps for n_grasps in n_grasps_per_object_list)
+n_grasps = n_grasps_per_object * N_OBJECTS
+
+# %%
+trans = np.stack([gc_dict["trans"] for gc_dict in grasp_config_dicts], axis=0)
+rot = np.stack([gc_dict["rot"] for gc_dict in grasp_config_dicts], axis=0)
+joint_angles = np.stack(
+    [gc_dict["joint_angles"] for gc_dict in grasp_config_dicts], axis=0
+)
+grasp_orientations = np.stack(
+    [gc_dict["grasp_orientations"] for gc_dict in grasp_config_dicts], axis=0
+)
+
+object_ids = np.stack(
+    [np.zeros(n_grasps_per_object) + i for i in range(N_OBJECTS)], axis=0
+)
+passed_evals = np.stack(
+    [gc_dict["passed_eval"] for gc_dict in grasp_config_dicts], axis=0
+)
+
+assert trans.shape == (N_OBJECTS, n_grasps_per_object, 3)
+assert rot.shape == (N_OBJECTS, n_grasps_per_object, 3, 3)
+assert joint_angles.shape == (N_OBJECTS, n_grasps_per_object, 16)
+assert grasp_orientations.shape == (N_OBJECTS, n_grasps_per_object, 4, 3, 3)
+assert object_ids.shape == (N_OBJECTS, n_grasps_per_object)
+assert passed_evals.shape == (N_OBJECTS, n_grasps_per_object)
+
+# %%
+print(f"N_OBJECTS: {N_OBJECTS}")
+print(f"n_grasps_per_object: {n_grasps_per_object}")
+print(f"n_grasps: {n_grasps}")
+
+
+# %%
+class GraspDataset(torch.utils.data.Dataset):
+    def __init__(
+        self,
+        trans: np.ndarray,
+        rot: np.ndarray,
+        joint_angles: np.ndarray,
+        grasp_orientations: np.ndarray,
+        object_ids: np.ndarray,
+        passed_evals: np.ndarray,
+    ) -> None:
+        super().__init__()
+        self.trans = torch.from_numpy(trans).float()
+        self.rot = torch.from_numpy(rot).float()
+        self.joint_angles = torch.from_numpy(joint_angles).float()
+        self.grasp_orientations = torch.from_numpy(grasp_orientations).float()
+        self.object_ids = torch.from_numpy(object_ids).long()
+        self.passed_evals = torch.from_numpy(passed_evals).float()
+
+        N = len(self)
+        assert trans.shape == (N, 3)
+        assert rot.shape == (N, 3, 3)
+        assert joint_angles.shape == (N, 16)
+        assert grasp_orientations.shape == (N, 4, 3, 3)
+        assert object_ids.shape == (N,)
+        assert passed_evals.shape == (N,)
+
+    def __len__(self) -> int:
+        return self.trans.shape[0]
+
+    def __getitem__(self, idx: int) -> tuple:
+        return (
+            self.trans[idx],
+            self.rot[idx],
+            self.joint_angles[idx],
+            self.grasp_orientations[idx],
+            self.object_ids[idx],
+            self.passed_evals[idx],
+        )
+
+
+all_grasp_dataset = GraspDataset(
+    trans=trans.reshape(-1, 3),
+    rot=rot.reshape(-1, 3, 3),
+    joint_angles=joint_angles.reshape(-1, 16),
+    grasp_orientations=grasp_orientations.reshape(-1, 4, 3, 3),
+    object_ids=object_ids.reshape(-1),
+    passed_evals=passed_evals.reshape(-1),
+)
+
+# %%
+train_dataset, val_dataset, test_dataset = torch.utils.data.random_split(
+    all_grasp_dataset,
+    [0.8, 0.1, 0.1],
+    generator=torch.Generator().manual_seed(42),
+)
+train_loader = torch.utils.data.DataLoader(
+    train_dataset, batch_size=cfg.batch_size, shuffle=True
+)
+val_loader = torch.utils.data.DataLoader(
+    val_dataset, batch_size=cfg.batch_size, shuffle=False
+)
+test_loader = torch.utils.data.DataLoader(
+    test_dataset, batch_size=cfg.batch_size, shuffle=False
+)
+
+
+# %%
+class GraspModel(torch.nn.Module):
+    def __init__(self, hidden_size: List[int]) -> None:
+        super().__init__()
+        input_size = 3 + 9 + 16 + 36 + N_OBJECTS
+        output_size = 2
+        self.fc_list = torch.nn.ModuleList()
+        sizes = [input_size] + hidden_size
+        for size1, size2 in zip(sizes[:-1], sizes[1:]):
+            self.fc_list.append(torch.nn.Linear(size1, size2))
+
+        self.fc_out = torch.nn.Linear(hidden_size[-1], output_size)
+
+    def forward(
+        self,
+        trans: torch.Tensor,
+        rot: torch.Tensor,
+        joint_angles: torch.Tensor,
+        grasp_orientations: torch.Tensor,
+        object_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size = trans.shape[0]
+        object_ids_onehot = torch.nn.functional.one_hot(
+            input=object_ids, num_classes=N_OBJECTS
+        ).float()
+
+        x = torch.cat(
+            [
+                trans.reshape(batch_size, -1),
+                rot.reshape(batch_size, -1),
+                joint_angles.reshape(batch_size, -1),
+                grasp_orientations.reshape(batch_size, -1),
+                object_ids_onehot.reshape(batch_size, -1),
+            ],
+            dim=1,
+        )
+        assert x.shape == (batch_size, 3 + 9 + 16 + 36 + N_OBJECTS)
+
+        for i, fc in enumerate(self.fc_list):
+            x = torch.nn.functional.relu(fc(x))
+        return self.fc_out(x)
+
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+model = GraspModel(hidden_size=cfg.hidden_size).to(device)
+model.train()
+
+# %%
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+train_losses_per_epoch, val_losses_per_epoch = [], []
+
+# %%
+# Compute class weight
+from sklearn.utils.class_weight import compute_class_weight
+passed_evals_rounded = (passed_evals.reshape(-1) > 0.01).astype(int)
+
+class_weight = compute_class_weight(
+    class_weight="balanced", classes=np.unique(passed_evals_rounded), y=passed_evals_rounded
+)
+
+# %%
+ce_loss_fn = torch.nn.CrossEntropyLoss(weight=torch.from_numpy(class_weight).float().to(device))
+
+
+# %%
+@localscope.mfc
+def train(
+    loader: torch.utils.data.DataLoader,
+    model: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+    loss_fn: torch.nn.Module,
+    device: str,
+) -> List[float]:
+    train_losses = []
+    n_batches = len(loader)
+    pbar = tqdm(loader, total=n_batches, desc="Training")
+    for trans, rot, joint_angles, grasp_orientations, object_ids, passed_evals in pbar:
+        optimizer.zero_grad()
+
+        trans = trans.to(device)
+        rot = rot.to(device)
+        joint_angles = joint_angles.to(device)
+        grasp_orientations = grasp_orientations.to(device)
+        object_ids = object_ids.to(device)
+        passed_evals = passed_evals.to(device)
+
+        pred = model(
+            trans=trans,
+            rot=rot,
+            joint_angles=joint_angles,
+            grasp_orientations=grasp_orientations,
+            object_ids=object_ids,
+        )
+        assert pred.shape == (len(passed_evals), 2)
+        assert passed_evals.shape == (len(passed_evals),)
+        assert torch.all(0 <= passed_evals) and torch.all(passed_evals <= 1)
+        passed_evals = torch.stack([1 - passed_evals, passed_evals], dim=1)
+        assert passed_evals.shape == pred.shape
+        assert torch.allclose(
+            torch.sum(passed_evals, dim=1), torch.ones(len(passed_evals)).to(device)
+        )
+        loss = loss_fn(input=pred, target=passed_evals)
+        loss.backward()
+        train_losses.append(loss.item())
+
+        optimizer.step()
+        pbar.set_description(f"Training, loss: {np.mean(train_losses):.4f}")
+    return train_losses
+
+
+@localscope.mfc
+def val(
+    loader: torch.utils.data.DataLoader,
+    model: torch.nn.Module,
+    loss_fn: torch.nn.Module,
+    device: str,
+) -> List[float]:
+    val_losses = []
+    n_batches = len(loader)
+    for trans, rot, joint_angles, grasp_orientations, object_ids, passed_evals in tqdm(
+        loader, total=n_batches, desc="Validation"
+    ):
+
+        trans = trans.to(device)
+        rot = rot.to(device)
+        joint_angles = joint_angles.to(device)
+        grasp_orientations = grasp_orientations.to(device)
+        object_ids = object_ids.to(device)
+        passed_evals = passed_evals.to(device)
+
+        with torch.no_grad():
+            pred = model(
+                trans=trans,
+                rot=rot,
+                joint_angles=joint_angles,
+                grasp_orientations=grasp_orientations,
+                object_ids=object_ids,
+            )
+            assert pred.shape == (len(passed_evals), 2)
+            assert passed_evals.shape == (len(passed_evals),)
+            assert torch.all(0 <= passed_evals) and torch.all(passed_evals <= 1)
+            passed_evals = torch.stack([1 - passed_evals, passed_evals], dim=1)
+            assert passed_evals.shape == pred.shape
+            assert torch.allclose(
+                torch.sum(passed_evals, dim=1), torch.ones(len(passed_evals)).to(device)
+            )
+            loss = loss_fn(input=pred, target=passed_evals)
+            val_losses.append(loss.item())
+
+    return val_losses
+
+
+# %%
+for epoch in tqdm(range(cfg.n_epochs), desc="Epoch"):
+    # Train
+    train_losses = train(
+        loader=train_loader,
+        model=model,
+        optimizer=optimizer,
+        loss_fn=ce_loss_fn,
+        device=device,
+    )
+    train_losses_per_epoch.append(np.mean(train_losses))
+
+    # Val
+    val_losses = val(loader=val_loader, model=model, loss_fn=ce_loss_fn, device=device)
+    val_losses_per_epoch.append(np.mean(val_losses))
+
+    print(f"{epoch=}, {train_losses_per_epoch[-1]=}, {val_losses_per_epoch[-1]=}")
+
+
+# %%
+plt.plot(train_losses_per_epoch, label="Train")
+plt.plot(val_losses_per_epoch, label="Val")
+plt.xlabel("Epoch")
+plt.ylabel("Loss")
+plt.legend()
+plt.show()
+
+# %%
+@localscope.mfc
+def get_prediction_and_truths(
+    loader: torch.utils.data.DataLoader,
+    model: torch.nn.Module,
+    device: str,
+) -> Tuple[np.ndarray, np.ndarray]:
+    n_batches = len(loader)
+    preds, truths = [], []
+    for trans, rot, joint_angles, grasp_orientations, object_ids, passed_evals in tqdm(
+        loader, total=n_batches, desc="Forward pass"
+    ):
+
+        trans = trans.to(device)
+        rot = rot.to(device)
+        joint_angles = joint_angles.to(device)
+        grasp_orientations = grasp_orientations.to(device)
+        object_ids = object_ids.to(device)
+        passed_evals = passed_evals.to(device)
+
+        with torch.no_grad():
+            pred = model(
+                trans=trans,
+                rot=rot,
+                joint_angles=joint_angles,
+                grasp_orientations=grasp_orientations,
+                object_ids=object_ids,
+            )
+            assert pred.shape == (len(passed_evals), 2)
+            assert passed_evals.shape == (len(passed_evals),)
+            assert torch.all(0 <= passed_evals) and torch.all(passed_evals <= 1)
+            passed_evals = torch.stack([1 - passed_evals, passed_evals], dim=1)
+            assert passed_evals.shape == pred.shape
+            assert torch.allclose(
+                torch.sum(passed_evals, dim=1), torch.ones(len(passed_evals)).to(device)
+            )
+            truths += passed_evals[:, 1].detach().cpu().numpy().tolist()
+            preds += torch.nn.functional.softmax(pred, dim=1)[:, 1].detach().cpu().numpy().tolist()
+
+    return np.array(preds), np.array(truths)
+
+# preds, truths = get_prediction_and_truths(loader=test_loader, model=model, device=device)
+preds, truths = get_prediction_and_truths(loader=train_loader, model=model, device=device)
+
+# %%
+noise = np.random.normal(0, 0.02, len(truths))
+plt.scatter(truths + noise, preds + noise, s=1)
+# %%
+@localscope.mfc
+def _create_histogram(
+    ground_truths: List[float],
+    predictions: List[float],
+    title: str,
+    match_ylims: bool = True,
+) -> plt.Figure:
+    unique_labels = np.unique(ground_truths)
+    fig, axes = plt.subplots(len(unique_labels), 1, figsize=(10, 20))
+    axes = axes.flatten()
+
+    # Get predictions per label
+    unique_labels_to_preds = {}
+    for i, unique_label in enumerate(unique_labels):
+        preds = np.array(predictions)
+        idxs = np.array(ground_truths) == unique_label
+        unique_labels_to_preds[unique_label] = preds[idxs]
+
+    # Plot histogram per label
+    for i, (unique_label, preds) in enumerate(
+        sorted(unique_labels_to_preds.items())
+    ):
+        axes[i].hist(preds, bins=50, alpha=0.7, color="blue")
+        axes[i].plot([unique_label, unique_label], axes[i].get_ylim(), c="r", label="Ground Truth")
+        axes[i].set_title(f"Ground Truth: {unique_label}")
+        axes[i].set_xlim(0, 1)
+        axes[i].set_xlabel("Prediction")
+        axes[i].set_ylabel("Count")
+
+    # Matching ylims
+    if match_ylims:
+        max_y_val = max(ax.get_ylim()[1] for ax in axes)
+        for i in range(len(axes)):
+            axes[i].set_ylim(0, max_y_val)
+
+    fig.suptitle(title)
+    fig.tight_layout()
+    return fig
+
+fig = _create_histogram(ground_truths=truths, predictions=preds, title="Grasp Metric", match_ylims=False)
+

--- a/nerf_grasping/baselines/nerf_to_mesh.py
+++ b/nerf_grasping/baselines/nerf_to_mesh.py
@@ -64,7 +64,7 @@ def nerf_to_mesh(
     min_len: Optional[float] = None,
     flip_faces: bool = True,
     save_path: Optional[Path] = None,
-) -> None:
+) -> trimesh.Trimesh:
     """Takes a nerfstudio pipeline field and plots or saves a mesh.
 
     Parameters
@@ -88,6 +88,11 @@ def nerf_to_mesh(
         (it appears that the faces are flipped inside out by default)
     save_path : Optional[Path], default=None
         The save path. If None, shows a plot instead.
+
+    Returns
+    -------
+    mesh : trimesh.Trimesh
+        The mesh.
     """
     # marching cubes
     sdf = lambda x: field.density_fn(x).cpu().detach().numpy() - level
@@ -126,6 +131,7 @@ def nerf_to_mesh(
         plt.show()
     else:
         mesh.export(save_path)
+    return mesh
 
 
 if __name__ == "__main__":

--- a/nerf_grasping/baselines/nerf_to_urdf.py
+++ b/nerf_grasping/baselines/nerf_to_urdf.py
@@ -13,7 +13,7 @@ from typing import Tuple
 @dataclass
 class Args:
     nerfcheckpoint_filepath: pathlib.Path
-    bounding_cube_half_length: float = 0.2
+    bounding_cube_half_length: float = 0.25
     density_of_0_level_set: float = 15.0
     n_pts_each_dim_marching_cubes: int = 31
     rescale: bool = True

--- a/nerf_grasping/classifier.py
+++ b/nerf_grasping/classifier.py
@@ -50,8 +50,10 @@ class Classifier(nn.Module):
         task_probs = nn.functional.softmax(PROB_SCALING * all_logits, dim=-1)
         passed_task_probs = task_probs[..., -1]
         assert_equals(passed_task_probs.shape, (batch_data_input.batch_size, n_tasks))
+
         # HACK: Modify to either be product or not
-        passed_all_probs = passed_task_probs[:, 0]
+        # passed_all_probs = passed_task_probs[:, 0]
+        passed_all_probs = passed_task_probs[:, -1]
         # passed_all_probs = torch.prod(passed_task_probs, dim=-1)
         assert_equals(passed_all_probs.shape, (batch_data_input.batch_size,))
 

--- a/nerf_grasping/classifier.py
+++ b/nerf_grasping/classifier.py
@@ -83,6 +83,33 @@ class Classifier(nn.Module):
         return 2
 
 
+class CNN_3D_XYZY_Classifier(Classifier):
+    def __init__(
+        self,
+        input_shape: Iterable[int],
+        conv_channels: Iterable[int],
+        mlp_hidden_layers: Iterable[int],
+        n_fingers: int,
+        n_tasks: int,
+    ) -> None:
+        super().__init__()
+        self.model = CNN_3D_Model(
+            input_shape=input_shape,
+            conv_channels=conv_channels,
+            mlp_hidden_layers=mlp_hidden_layers,
+            n_fingers=n_fingers,
+            n_tasks=n_tasks,
+        )
+
+    def forward(self, batch_data_input: BatchDataInput) -> torch.Tensor:
+        # Run model
+        all_logits = self.model.get_all_logits(
+            batch_data_input.nerf_alphas_with_augmented_coords_v3
+        )
+        return all_logits
+
+
+
 class CNN_3D_XYZXYZY_Classifier(Classifier):
     def __init__(
         self,

--- a/nerf_grasping/classifier.py
+++ b/nerf_grasping/classifier.py
@@ -83,6 +83,32 @@ class Classifier(nn.Module):
         return 2
 
 
+class CNN_3D_XYZXYZY_Classifier(Classifier):
+    def __init__(
+        self,
+        input_shape: Iterable[int],
+        conv_channels: Iterable[int],
+        mlp_hidden_layers: Iterable[int],
+        n_fingers: int,
+        n_tasks: int,
+    ) -> None:
+        super().__init__()
+        self.model = CNN_3D_Model(
+            input_shape=input_shape,
+            conv_channels=conv_channels,
+            mlp_hidden_layers=mlp_hidden_layers,
+            n_fingers=n_fingers,
+            n_tasks=n_tasks,
+        )
+
+    def forward(self, batch_data_input: BatchDataInput) -> torch.Tensor:
+        # Run model
+        all_logits = self.model.get_all_logits(
+            batch_data_input.nerf_alphas_with_augmented_coords_v2
+        )
+        return all_logits
+
+
 class CNN_3D_XYZ_Classifier(Classifier):
     def __init__(
         self,

--- a/nerf_grasping/classifier.py
+++ b/nerf_grasping/classifier.py
@@ -50,7 +50,9 @@ class Classifier(nn.Module):
         task_probs = nn.functional.softmax(PROB_SCALING * all_logits, dim=-1)
         passed_task_probs = task_probs[..., -1]
         assert_equals(passed_task_probs.shape, (batch_data_input.batch_size, n_tasks))
-        passed_all_probs = torch.prod(passed_task_probs, dim=-1)
+        # HACK: Modify to either be product or not
+        passed_all_probs = passed_task_probs[:, 0]
+        # passed_all_probs = torch.prod(passed_task_probs, dim=-1)
         assert_equals(passed_all_probs.shape, (batch_data_input.batch_size,))
 
         # Return failure probabilities (as loss).

--- a/nerf_grasping/classifier.py
+++ b/nerf_grasping/classifier.py
@@ -136,6 +136,32 @@ class CNN_3D_XYZXYZY_Classifier(Classifier):
         return all_logits
 
 
+class CNN_3D_XYZXYZ_Classifier(Classifier):
+    def __init__(
+        self,
+        input_shape: Iterable[int],
+        conv_channels: Iterable[int],
+        mlp_hidden_layers: Iterable[int],
+        n_fingers: int,
+        n_tasks: int,
+    ) -> None:
+        super().__init__()
+        self.model = CNN_3D_Model(
+            input_shape=input_shape,
+            conv_channels=conv_channels,
+            mlp_hidden_layers=mlp_hidden_layers,
+            n_fingers=n_fingers,
+            n_tasks=n_tasks,
+        )
+
+    def forward(self, batch_data_input: BatchDataInput) -> torch.Tensor:
+        # Run model
+        all_logits = self.model.get_all_logits(
+            batch_data_input.nerf_alphas_with_augmented_coords_v4
+        )
+        return all_logits
+
+
 class CNN_3D_XYZ_Classifier(Classifier):
     def __init__(
         self,

--- a/nerf_grasping/config/classifier_config.py
+++ b/nerf_grasping/config/classifier_config.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Literal, Tuple, List, Union
 from nerf_grasping.config.fingertip_config import UnionFingertipConfig
 from nerf_grasping.classifier import (
+    CNN_3D_XYZXYZY_Classifier,
     CNN_3D_XYZ_Classifier,
     CNN_2D_1D_Classifier,
     Simple_CNN_2D_1D_Classifier,
@@ -267,6 +268,42 @@ class ClassifierModelConfig:
 
 
 @dataclass(frozen=True)
+class CNN_3D_XYZXYZY_ModelConfig(ClassifierModelConfig):
+    """"Parameters for the CNN_3D_XYZXYZY_Classifier."""
+
+    conv_channels: List[int]
+    """List of channels for each convolutional layer. Length specifies number of layers."""
+
+    mlp_hidden_layers: List[int]
+    """List of hidden layer sizes for the MLP. Length specifies number of layers."""
+
+    n_fingers: int = 4
+    """Number of fingers."""
+
+    def input_shape_from_fingertip_config(self, fingertip_config: UnionFingertipConfig):
+        n_density_channels = 1
+        n_xyz_channels = 3
+        n_y_channels = 1
+        return [
+            n_density_channels + n_xyz_channels + n_xyz_channels + n_y_channels,
+            fingertip_config.num_pts_x,
+            fingertip_config.num_pts_y,
+            fingertip_config.num_pts_z,
+        ]
+
+    def get_classifier_from_fingertip_config(self, fingertip_config: UnionFingertipConfig, n_tasks: int) -> Classifier:
+        """Helper method to return the correct classifier from config."""
+
+        input_shape = self.input_shape_from_fingertip_config(fingertip_config)
+        return CNN_3D_XYZXYZY_Classifier(
+            input_shape=input_shape,
+            n_fingers=fingertip_config.n_fingers,
+            n_tasks=n_tasks,
+            conv_channels=self.conv_channels,
+            mlp_hidden_layers=self.mlp_hidden_layers,
+        )
+
+@dataclass(frozen=True)
 class CNN_3D_XYZ_ModelConfig(ClassifierModelConfig):
     """Parameters for the CNN_3D_XYZ_Classifier."""
 
@@ -280,8 +317,10 @@ class CNN_3D_XYZ_ModelConfig(ClassifierModelConfig):
     """Number of fingers."""
 
     def input_shape_from_fingertip_config(self, fingertip_config: UnionFingertipConfig):
+        n_density_channels = 1
+        n_xyz_channels = 3
         return [
-            4,
+            n_density_channels + n_xyz_channels,
             fingertip_config.num_pts_x,
             fingertip_config.num_pts_y,
             fingertip_config.num_pts_z,
@@ -581,6 +620,12 @@ class ClassifierConfig:
 
 
 DEFAULTS_DICT = {
+    "cnn-3d-xyzxyzy": ClassifierConfig(
+        model_config=CNN_3D_XYZXYZY_ModelConfig(
+            conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256]
+        ),
+        nerfdata_config=GridNerfDataConfig(),
+    ),
     "cnn-3d-xyz": ClassifierConfig(
         model_config=CNN_3D_XYZ_ModelConfig(
             conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256]

--- a/nerf_grasping/config/classifier_config.py
+++ b/nerf_grasping/config/classifier_config.py
@@ -39,6 +39,7 @@ class TaskType(Enum):
     PASSED_PENETRATION_THRESHOLD = auto()
     PASSED_EVAL = auto()
     PASSED_SIMULATION_AND_PENETRATION_THRESHOLD = auto()
+    PASSED_SIMULATION_AND_PENETRATION_THRESHOLD_AND_EVAL = auto()
 
     @property
     def n_tasks(self) -> int:
@@ -56,6 +57,12 @@ class TaskType(Enum):
             return [
                 "passed_simulation",
                 "passed_penetration_threshold",
+            ]
+        elif self == TaskType.PASSED_SIMULATION_AND_PENETRATION_THRESHOLD_AND_EVAL:
+            return [
+                "passed_simulation",
+                "passed_penetration_threshold",
+                "passed_eval",
             ]
         else:
             raise ValueError(f"Unknown task_type: {self}")

--- a/nerf_grasping/config/classifier_config.py
+++ b/nerf_grasping/config/classifier_config.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Literal, Tuple, List, Union
 from nerf_grasping.config.fingertip_config import UnionFingertipConfig
 from nerf_grasping.classifier import (
+    CNN_3D_XYZXYZ_Classifier,
     CNN_3D_XYZXYZY_Classifier,
     CNN_3D_XYZY_Classifier,
     CNN_3D_XYZ_Classifier,
@@ -341,6 +342,43 @@ class CNN_3D_XYZXYZY_ModelConfig(ClassifierModelConfig):
             mlp_hidden_layers=self.mlp_hidden_layers,
         )
 
+
+@dataclass(frozen=True)
+class CNN_3D_XYZXYZ_ModelConfig(ClassifierModelConfig):
+    """"Parameters for the CNN_3D_XYZXYZ_Classifier."""
+
+    conv_channels: List[int]
+    """List of channels for each convolutional layer. Length specifies number of layers."""
+
+    mlp_hidden_layers: List[int]
+    """List of hidden layer sizes for the MLP. Length specifies number of layers."""
+
+    n_fingers: int = 4
+    """Number of fingers."""
+
+    def input_shape_from_fingertip_config(self, fingertip_config: UnionFingertipConfig):
+        n_density_channels = 1
+        n_xyz_channels = 3
+        return [
+            n_density_channels + n_xyz_channels + n_xyz_channels,
+            fingertip_config.num_pts_x,
+            fingertip_config.num_pts_y,
+            fingertip_config.num_pts_z,
+        ]
+
+    def get_classifier_from_fingertip_config(self, fingertip_config: UnionFingertipConfig, n_tasks: int) -> Classifier:
+        """Helper method to return the correct classifier from config."""
+
+        input_shape = self.input_shape_from_fingertip_config(fingertip_config)
+        return CNN_3D_XYZXYZ_Classifier(
+            input_shape=input_shape,
+            n_fingers=fingertip_config.n_fingers,
+            n_tasks=n_tasks,
+            conv_channels=self.conv_channels,
+            mlp_hidden_layers=self.mlp_hidden_layers,
+        )
+
+
 @dataclass(frozen=True)
 class CNN_3D_XYZ_ModelConfig(ClassifierModelConfig):
     """Parameters for the CNN_3D_XYZ_Classifier."""
@@ -658,6 +696,12 @@ class ClassifierConfig:
 
 
 DEFAULTS_DICT = {
+    "cnn-3d-xyzxyz": ClassifierConfig(
+        model_config=CNN_3D_XYZXYZ_ModelConfig(
+            conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256]
+        ),
+        nerfdata_config=GridNerfDataConfig(),
+    ),
     "cnn-3d-xyzy": ClassifierConfig(
         model_config=CNN_3D_XYZY_ModelConfig(
             conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256]

--- a/nerf_grasping/config/grasp_metric_config.py
+++ b/nerf_grasping/config/grasp_metric_config.py
@@ -32,7 +32,7 @@ class GraspMetricConfig:
         / "2024-01-03_235839"
         / "config.yml"
     )
-    object_transform_world_frame: Optional[np.ndarray] = None
+    X_N_Oy: Optional[np.ndarray] = None
 
     def __post_init__(self):
         """
@@ -46,8 +46,8 @@ class GraspMetricConfig:
         else:
             print("Loading default classifier config.")
 
-        if self.object_transform_world_frame is None:
-            self.object_transform_world_frame = np.eye(4)
+        if self.X_N_Oy is None:
+            self.X_N_Oy = np.eye(4)
 
     @property
     def object_name(self) -> str:

--- a/nerf_grasping/config/nerfdata_config.py
+++ b/nerf_grasping/config/nerfdata_config.py
@@ -39,7 +39,7 @@ class BaseNerfDataConfig:
     limit_num_configs: Optional[int] = None  # None for no limit
     max_num_data_points_per_file: Optional[
         int
-    ] = 15_000  # None for count actual num data points, set to avoid OOM
+    ] = None  # None for count actual num data points, set to avoid OOM
     ray_samples_chunk_size: int = 50  # ~8GB on GPU
     cameras_samples_chunk_size: int = 2000  # ~14GB on GPU
     plot_all_high_density_points: bool = True

--- a/nerf_grasping/config/optimizer_config.py
+++ b/nerf_grasping/config/optimizer_config.py
@@ -4,7 +4,7 @@ import tyro
 
 @dataclass
 class BaseOptimizerConfig:
-    num_grasps: int = 20
+    num_grasps: int = 32
     num_steps: int = 30
 
 

--- a/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
+++ b/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
@@ -65,155 +65,6 @@ from localscope import localscope
 from nerfstudio.fields.base_field import Field
 from nerfstudio.models.base_model import Model
 
-# %%
-
-# %%
-@localscope.mfc(allowed=["cfg"])
-def get_stuff(evaled_grasp_config_dict_filepath: pathlib.Path):
-    with loop_timer.add_section_timer("prepare to read in data"):
-        object_code_and_scale_str = evaled_grasp_config_dict_filepath.stem
-        object_code, object_scale = parse_object_code_and_scale(
-            object_code_and_scale_str
-        )
-
-        # Get nerf config
-        nerf_config = get_closest_matching_nerf_config(
-            target_object_code_and_scale_str=object_code_and_scale_str,
-            nerf_configs=nerf_configs,
-        )
-
-        # Check that mesh and grasp dataset exist
-        assert os.path.exists(
-            evaled_grasp_config_dict_filepath
-        ), f"evaled_grasp_config_dict_filepath {evaled_grasp_config_dict_filepath} does not exist"
-
-    with loop_timer.add_section_timer("load grasp data"):
-        evaled_grasp_config_dict: Dict[str, Any] = np.load(
-            evaled_grasp_config_dict_filepath, allow_pickle=True
-        ).item()
-
-    # Extract useful parts of grasp data
-    grasp_configs = AllegroGraspConfig.from_grasp_config_dict(
-        evaled_grasp_config_dict
-    )
-    passed_evals = evaled_grasp_config_dict["passed_eval"]
-    passed_simulations = evaled_grasp_config_dict["passed_simulation"]
-    passed_penetration_thresholds = evaled_grasp_config_dict[
-        # TODO: Choose which label to use
-        # "passed_penetration_threshold"
-        "passed_new_penetration_test"
-    ]
-    object_state = evaled_grasp_config_dict["object_states_before_grasp"]
-
-    # If plot_only_one is True, slice out the grasp index we want to visualize.
-    if cfg.plot_only_one:
-        assert cfg.grasp_visualize_index is not None
-        assert (
-            cfg.grasp_visualize_index < grasp_configs.batch_size
-        ), f"{cfg.grasp_visualize_index} out of bounds for batch size {grasp_configs.batch_size}"
-        grasp_configs = grasp_configs[
-            cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
-        ]
-        passed_evals = passed_evals[
-            cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
-        ]
-        passed_simulations = passed_simulations[
-            cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
-        ]
-        passed_penetration_thresholds = passed_penetration_thresholds[
-            cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
-        ]
-        object_state = object_state[
-            cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
-        ]
-
-    print(f"grasp_configs.batch_size = {grasp_configs.batch_size}")
-    if (
-        cfg.max_num_data_points_per_file is not None
-        and grasp_configs.batch_size > cfg.max_num_data_points_per_file
-    ):
-        print(
-            "WARNING: Too many grasp configs, dropping some datapoints from NeRF dataset."
-        )
-        print(
-            f"batch_size = {grasp_configs.batch_size}, cfg.max_num_data_points_per_file = {cfg.max_num_data_points_per_file}"
-        )
-
-        grasp_configs = grasp_configs[:cfg.max_num_data_points_per_file]
-
-        passed_evals = passed_evals[:cfg.max_num_data_points_per_file]
-        passed_simulations = passed_simulations[:cfg.max_num_data_points_per_file]
-        passed_penetration_thresholds = passed_penetration_thresholds[
-            :cfg.max_num_data_points_per_file
-        ]
-        object_state = object_state[:cfg.max_num_data_points_per_file]
-
-    grasp_frame_transforms = grasp_configs.grasp_frame_transforms
-    grasp_config_tensors = grasp_configs.as_tensor().detach().cpu().numpy()
-
-    assert_equals(passed_evals.shape, (grasp_configs.batch_size,))
-    assert_equals(passed_simulations.shape, (grasp_configs.batch_size,))
-    assert_equals(passed_penetration_thresholds.shape, (grasp_configs.batch_size,))
-    assert_equals(
-        grasp_frame_transforms.lshape,
-        (
-            grasp_configs.batch_size,
-            cfg.fingertip_config.n_fingers,
-        ),
-    )
-    assert_equals(
-        grasp_config_tensors.shape,
-        (
-            grasp_configs.batch_size,
-            cfg.fingertip_config.n_fingers,
-            7
-            + 16
-            + 4,  # wrist pose, joint angles, grasp orientations (as quats)
-        ),
-    )
-    # Annoying hack because I stored all the object states for multiple noise runs, only need 1
-    assert len(object_state.shape) == 3
-    n_runs = object_state.shape[1]
-    assert_equals(object_state.shape, (grasp_configs.batch_size, n_runs, 13))
-    object_state = object_state[:, 0]
-
-    if isinstance(cfg, GridNerfDataConfig):
-        # Process batch of grasp data.
-        nerf_densities, query_points = get_nerf_densities(
-            loop_timer=loop_timer,
-            cfg=cfg,
-            grasp_frame_transforms=grasp_frame_transforms,
-            ray_origins_finger_frame=ray_origins_finger_frame,
-            nerf_config=nerf_config,
-            compute_query_points=cfg.plot_only_one,
-        )
-    elif isinstance(cfg, DepthImageNerfDataConfig):
-        depth_images, uncertainty_images = get_depth_and_uncertainty_images(
-            loop_timer=loop_timer,
-            cfg=cfg,
-            grasp_frame_transforms=grasp_frame_transforms,
-            nerf_config=nerf_config,
-        )
-    return (
-        nerf_densities,
-        query_points,
-        depth_images,
-        uncertainty_images,
-        passed_evals,
-        passed_simulations,
-        passed_penetration_thresholds,
-        nerf_config,
-        object_code,
-        object_scale,
-        object_state,
-        grasp_idx,
-        grasp_transforms,
-        grasp_configs,
-    )
-
-
-# %%
-
 
 # %%
 def assert_equals(a, b):
@@ -876,106 +727,226 @@ with h5py.File(cfg.output_filepath, "w") as hdf5_file:
         dynamic_ncols=True,
     )
     for evaled_grasp_config_dict_filepath in pbar:
-        pbar.set_description(f"Processing {evaled_grasp_config_dict_filepath}")
         # HACK: weird fragmentation issues slightly resolved by emptying cache
         torch.cuda.empty_cache()
 
         # HACK: debugging memory leaks
         print(torch.cuda.memory_summary())
 
-        (nerf_densities,
-        query_points,
-        depth_images,
-        uncertainty_images,
-        passed_evals,
-        passed_simulations,
-        passed_penetration_thresholds,
-        nerf_config,
-        object_code,
-        object_scale,
-        object_state,
-        grasp_idx,
-        grasp_transforms,
-        grasp_configs,) = get_stuff(evaled_grasp_config_dict_filepath)
+        pbar.set_description(f"Processing {evaled_grasp_config_dict_filepath}")
+        try:
+            with loop_timer.add_section_timer("prepare to read in data"):
+                object_code_and_scale_str = evaled_grasp_config_dict_filepath.stem
+                object_code, object_scale = parse_object_code_and_scale(
+                    object_code_and_scale_str
+                )
 
-        if nerf_densities.isnan().any():
-            print("\n" + "-" * 80)
-            print(
-                f"WARNING: Found {nerf_densities.isnan().sum()} nerf density nans in {nerf_config}"
-            )
-            print("Skipping this one...")
-            print("-" * 80 + "\n")
-            raise ValueError("Nerf density nans")
+                # Get nerf config
+                nerf_config = get_closest_matching_nerf_config(
+                    target_object_code_and_scale_str=object_code_and_scale_str,
+                    nerf_configs=nerf_configs,
+                )
 
-        if depth_images.isnan().any():
-            print("\n" + "-" * 80)
-            print(
-                f"WARNING: Found {depth_images.isnan().sum()} depth image nans in {nerf_config}"
-            )
-            print("Skipping this one...")
-            print("-" * 80 + "\n")
-            raise ValueError("Depth image nans")
+                # Check that mesh and grasp dataset exist
+                assert os.path.exists(
+                    evaled_grasp_config_dict_filepath
+                ), f"evaled_grasp_config_dict_filepath {evaled_grasp_config_dict_filepath} does not exist"
 
-        # Ensure no nans (most likely come from weird grasp transforms)
-        if grasp_transforms.isnan().any():
-            print("\n" + "-" * 80)
-            print(
-                f"WARNING: Found {grasp_transforms.isnan().sum()} transform nans in {evaled_grasp_config_dict_filepath}"
-            )
-            print("Skipping this one...")
-            print("-" * 80 + "\n")
-            continue
+            with loop_timer.add_section_timer("load grasp data"):
+                evaled_grasp_config_dict: Dict[str, Any] = np.load(
+                    evaled_grasp_config_dict_filepath, allow_pickle=True
+                ).item()
 
-        # Save values
-        if not cfg.save_dataset:
-            continue
+            # Extract useful parts of grasp data
+            grasp_configs = AllegroGraspConfig.from_grasp_config_dict(
+                evaled_grasp_config_dict
+            )
+            passed_evals = evaled_grasp_config_dict["passed_eval"]
+            passed_simulations = evaled_grasp_config_dict["passed_simulation"]
+            passed_penetration_thresholds = evaled_grasp_config_dict[
+                # TODO: Choose which label to use
+                # "passed_penetration_threshold"
+                "passed_new_penetration_test"
+            ]
+            object_state = evaled_grasp_config_dict["object_states_before_grasp"]
 
-        with loop_timer.add_section_timer("save values"):
-            prev_idx = current_idx
-            current_idx += grasp_configs.batch_size
-            passed_eval_dataset[prev_idx:current_idx] = passed_evals
-            passed_simulation_dataset[prev_idx:current_idx] = passed_simulations
-            passed_penetration_threshold_dataset[
-                prev_idx:current_idx
-            ] = passed_penetration_thresholds
-            nerf_config_dataset[prev_idx:current_idx] = [str(nerf_config)] * (
-                current_idx - prev_idx
+            # If plot_only_one is True, slice out the grasp index we want to visualize.
+            if cfg.plot_only_one:
+                assert cfg.grasp_visualize_index is not None
+                assert (
+                    cfg.grasp_visualize_index < grasp_configs.batch_size
+                ), f"{cfg.grasp_visualize_index} out of bounds for batch size {grasp_configs.batch_size}"
+                grasp_configs = grasp_configs[
+                    cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
+                ]
+                passed_evals = passed_evals[
+                    cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
+                ]
+                passed_simulations = passed_simulations[
+                    cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
+                ]
+                passed_penetration_thresholds = passed_penetration_thresholds[
+                    cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
+                ]
+                object_state = object_state[
+                    cfg.grasp_visualize_index : cfg.grasp_visualize_index + 1
+                ]
+
+            print(f"grasp_configs.batch_size = {grasp_configs.batch_size}")
+            if (
+                cfg.max_num_data_points_per_file is not None
+                and grasp_configs.batch_size > cfg.max_num_data_points_per_file
+            ):
+                print(
+                    "WARNING: Too many grasp configs, dropping some datapoints from NeRF dataset."
+                )
+                print(
+                    f"batch_size = {grasp_configs.batch_size}, cfg.max_num_data_points_per_file = {cfg.max_num_data_points_per_file}"
+                )
+
+                grasp_configs = grasp_configs[:cfg.max_num_data_points_per_file]
+
+                passed_evals = passed_evals[:cfg.max_num_data_points_per_file]
+                passed_simulations = passed_simulations[:cfg.max_num_data_points_per_file]
+                passed_penetration_thresholds = passed_penetration_thresholds[
+                    :cfg.max_num_data_points_per_file
+                ]
+                object_state = object_state[:cfg.max_num_data_points_per_file]
+
+            grasp_frame_transforms = grasp_configs.grasp_frame_transforms
+            grasp_config_tensors = grasp_configs.as_tensor().detach().cpu().numpy()
+
+            assert_equals(passed_evals.shape, (grasp_configs.batch_size,))
+            assert_equals(passed_simulations.shape, (grasp_configs.batch_size,))
+            assert_equals(passed_penetration_thresholds.shape, (grasp_configs.batch_size,))
+            assert_equals(
+                grasp_frame_transforms.lshape,
+                (
+                    grasp_configs.batch_size,
+                    cfg.fingertip_config.n_fingers,
+                ),
             )
-            object_code_dataset[prev_idx:current_idx] = [object_code] * (
-                current_idx - prev_idx
+            assert_equals(
+                grasp_config_tensors.shape,
+                (
+                    grasp_configs.batch_size,
+                    cfg.fingertip_config.n_fingers,
+                    7
+                    + 16
+                    + 4,  # wrist pose, joint angles, grasp orientations (as quats)
+                ),
             )
-            object_scale_dataset[prev_idx:current_idx] = object_scale
-            object_state_dataset[prev_idx:current_idx] = object_state
-            grasp_idx_dataset[prev_idx:current_idx] = np.arange(
-                0, current_idx - prev_idx
-            )
-            grasp_transforms_dataset[prev_idx:current_idx] = (
-                grasp_transforms.matrix().cpu().detach().numpy()
-            )
+            # Annoying hack because I stored all the object states for multiple noise runs, only need 1
+            assert len(object_state.shape) == 3
+            n_runs = object_state.shape[1]
+            assert_equals(object_state.shape, (grasp_configs.batch_size, n_runs, 13))
+            object_state = object_state[:, 0]
 
             if isinstance(cfg, GridNerfDataConfig):
-                nerf_densities_dataset[prev_idx:current_idx] = (
-                    nerf_densities.detach().cpu().numpy()
+                # Process batch of grasp data.
+                nerf_densities, query_points = get_nerf_densities(
+                    loop_timer=loop_timer,
+                    cfg=cfg,
+                    grasp_frame_transforms=grasp_frame_transforms,
+                    ray_origins_finger_frame=ray_origins_finger_frame,
+                    nerf_config=nerf_config,
+                    compute_query_points=cfg.plot_only_one,
                 )
-                del nerf_densities
+                if nerf_densities.isnan().any():
+                    print("\n" + "-" * 80)
+                    print(
+                        f"WARNING: Found {nerf_densities.isnan().sum()} nerf density nans in {nerf_config}"
+                    )
+                    print("Skipping this one...")
+                    print("-" * 80 + "\n")
+                    continue
 
-            if isinstance(cfg, DepthImageNerfDataConfig):
-                depth_images_dataset[prev_idx:current_idx] = (
-                    depth_images.detach().cpu().numpy()
+            elif isinstance(cfg, DepthImageNerfDataConfig):
+                depth_images, uncertainty_images = get_depth_and_uncertainty_images(
+                    loop_timer=loop_timer,
+                    cfg=cfg,
+                    grasp_frame_transforms=grasp_frame_transforms,
+                    nerf_config=nerf_config,
                 )
-                uncertainty_images_dataset[prev_idx:current_idx] = (
-                    uncertainty_images.detach().cpu().numpy()
+                if depth_images.isnan().any():
+                    print("\n" + "-" * 80)
+                    print(
+                        f"WARNING: Found {depth_images.isnan().sum()} depth image nans in {nerf_config}"
+                    )
+                    print("Skipping this one...")
+                    print("-" * 80 + "\n")
+                    continue
+
+            if cfg.plot_only_one:
+                break
+
+            # Ensure no nans (most likely come from weird grasp transforms)
+            if grasp_frame_transforms.isnan().any():
+                print("\n" + "-" * 80)
+                print(
+                    f"WARNING: Found {grasp_frame_transforms.isnan().sum()} transform nans in {evaled_grasp_config_dict_filepath}"
                 )
-                del depth_images, uncertainty_images
+                print("Skipping this one...")
+                print("-" * 80 + "\n")
+                continue
 
-            grasp_configs_dataset[prev_idx:current_idx] = grasp_config_tensors
+            # Save values
+            if not cfg.save_dataset:
+                continue
 
-            # May not be max_num_data_points if nan grasps
-            hdf5_file.attrs["num_data_points"] = current_idx
+            with loop_timer.add_section_timer("save values"):
+                prev_idx = current_idx
+                current_idx += grasp_configs.batch_size
+                passed_eval_dataset[prev_idx:current_idx] = passed_evals
+                passed_simulation_dataset[prev_idx:current_idx] = passed_simulations
+                passed_penetration_threshold_dataset[
+                    prev_idx:current_idx
+                ] = passed_penetration_thresholds
+                nerf_config_dataset[prev_idx:current_idx] = [str(nerf_config)] * (
+                    current_idx - prev_idx
+                )
+                object_code_dataset[prev_idx:current_idx] = [object_code] * (
+                    current_idx - prev_idx
+                )
+                object_scale_dataset[prev_idx:current_idx] = object_scale
+                object_state_dataset[prev_idx:current_idx] = object_state
+                grasp_idx_dataset[prev_idx:current_idx] = np.arange(
+                    0, current_idx - prev_idx
+                )
+                grasp_transforms_dataset[prev_idx:current_idx] = (
+                    grasp_frame_transforms.matrix().cpu().detach().numpy()
+                )
 
-        # HACK: debugging memory leaks
-        print("End of loop")
-        print(torch.cuda.memory_summary())
+                if isinstance(cfg, GridNerfDataConfig):
+                    nerf_densities_dataset[prev_idx:current_idx] = (
+                        nerf_densities.detach().cpu().numpy()
+                    )
+                    del nerf_densities
+
+                if isinstance(cfg, DepthImageNerfDataConfig):
+                    depth_images_dataset[prev_idx:current_idx] = (
+                        depth_images.detach().cpu().numpy()
+                    )
+                    uncertainty_images_dataset[prev_idx:current_idx] = (
+                        uncertainty_images.detach().cpu().numpy()
+                    )
+                    del depth_images, uncertainty_images
+
+                grasp_configs_dataset[prev_idx:current_idx] = grasp_config_tensors
+
+                # May not be max_num_data_points if nan grasps
+                hdf5_file.attrs["num_data_points"] = current_idx
+
+            # HACK: debugging memory leaks
+            print("End of loop")
+            print(torch.cuda.memory_summary())
+        except Exception as e:
+            print("\n" + "-" * 80)
+            print(f"WARNING: Failed to process {evaled_grasp_config_dict_filepath}")
+            print(f"Exception: {e}")
+            print("Skipping this one...")
+            print("-" * 80 + "\n")
+            continue
 
         if cfg.print_timing:
             loop_timer.pretty_print_section_times()
@@ -986,8 +957,8 @@ if not cfg.plot_only_one:
     print("Done!")
     sys.exit()
 
-grasp_transforms = (
-    grasp_transforms.matrix().cpu().detach().numpy()[cfg.grasp_visualize_index]
+grasp_frame_transforms = (
+    grasp_frame_transforms.matrix().cpu().detach().numpy()[cfg.grasp_visualize_index]
 )
 # Plot
 delta = (
@@ -1018,7 +989,7 @@ if "nerf_densities" in globals():
 fig2 = plot_mesh_and_transforms(
     mesh=mesh,
     transforms=[
-        grasp_transforms[i] for i in range(cfg.fingertip_config.n_fingers)
+        grasp_frame_transforms[i] for i in range(cfg.fingertip_config.n_fingers)
     ],
     num_fingers=cfg.fingertip_config.n_fingers,
     title=f"Mesh and Transforms, Success: {passed_evals[cfg.grasp_visualize_index]}",
@@ -1164,11 +1135,3 @@ if "depth_images" in globals():
     plt.show(block=True)
 
 assert False, "cfg.plot_only_one is True"
-
-
-# %%
-Mu = 1
-
-@localscope.mfc
-def compute_gaussian(x, mu, std):
-    return np.exp(-0.5 * ((x - Mu) / std) ** 2) / (std * np.sqrt(2 * np.pi))

--- a/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
+++ b/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
@@ -768,7 +768,7 @@ with h5py.File(cfg.output_filepath, "w") as hdf5_file:
                 # "passed_penetration_threshold"
                 "passed_new_penetration_test"
             ]
-            object_state = evaled_grasp_config_dict["object_state"]
+            object_state = evaled_grasp_config_dict["object_states_before_grasp"]
 
             # If plot_only_one is True, slice out the grasp index we want to visualize.
             if cfg.plot_only_one:

--- a/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
+++ b/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
@@ -257,13 +257,8 @@ def plot_mesh_and_high_density_points(
 
     fig.update_layout(
         legend_orientation="h",
-        scene=dict(
-            xaxis=dict(nticks=4, range=[-0.1, 0.1]),
-            yaxis=dict(nticks=4, range=[-0.1, 0.1]),
-            zaxis=dict(nticks=4, range=[-0.1, 0.1]),
-        ),
     )  # Avoid overlapping legend
-    fig.update_layout(scene_aspectmode="cube")
+    fig.update_layout(scene_aspectmode="data")
     return fig
 
 

--- a/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
+++ b/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
@@ -273,6 +273,30 @@ def get_ray_samples_in_mesh_region(
     min_bounds, max_bounds = mesh.bounds * beyond_mesh_region_scale
     x_min, y_min, z_min = min_bounds
     x_max, y_max, z_max = max_bounds
+    return get_ray_samples_in_region(
+        x_min=x_min,
+        x_max=x_max,
+        y_min=y_min,
+        y_max=y_max,
+        z_min=z_min,
+        z_max=z_max,
+        num_pts_x=num_pts_x,
+        num_pts_y=num_pts_y,
+        num_pts_z=num_pts_z,
+    )
+
+def get_ray_samples_in_region(
+    x_min: float,
+    x_max: float,
+    y_min: float,
+    y_max: float,
+    z_min: float,
+    z_max: float,
+    num_pts_x: int,
+    num_pts_y: int,
+    num_pts_z: int,
+) -> RaySamples:
+    # Get bounds from mesh
     finger_width_mm = (x_max - x_min) * 1000
     finger_height_mm = (y_max - y_min) * 1000
     grasp_depth_mm = (z_max - z_min) * 1000

--- a/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
+++ b/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
@@ -135,6 +135,13 @@ class BatchDataInput:
         )
 
     @property
+    def nerf_alphas_with_coords_v4(self) -> torch.Tensor:
+        return self._nerf_alphas_with_coords_v4_helper(
+            self.coords,
+            self.coords_wrt_wrist,
+        )
+
+    @property
     def nerf_alphas_with_augmented_coords(self) -> torch.Tensor:
         return self._nerf_alphas_with_coords_helper(self.augmented_coords)
 
@@ -151,6 +158,13 @@ class BatchDataInput:
         return self._nerf_alphas_with_coords_v3_helper(
             self.augmented_coords,
             self.augmented_y_coords_wrt_table,
+        )
+
+    @property
+    def nerf_alphas_with_augmented_coords_v4(self) -> torch.Tensor:
+        return self._nerf_alphas_with_coords_v4_helper(
+            self.augmented_coords,
+            self.augmented_coords_wrt_wrist,
         )
 
     @property
@@ -472,6 +486,54 @@ class BatchDataInput:
             self.batch_size,
             self.fingertip_config.n_fingers,
             NUM_XYZ + 1 + NUM_Y,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        return return_value
+
+    def _nerf_alphas_with_coords_v4_helper(
+        self,
+        coords: torch.Tensor,
+        coords_wrt_wrist: torch.Tensor,
+    ) -> torch.Tensor:
+        assert coords.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        assert coords_wrt_wrist.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+
+        reshaped_nerf_alphas = self.nerf_alphas.reshape(
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            1,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        return_value = torch.cat(
+            [
+                reshaped_nerf_alphas,
+                coords,
+                coords_wrt_wrist,
+            ],
+            dim=2,
+        )
+        assert return_value.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ + 1 + NUM_XYZ,
             self.fingertip_config.num_pts_x,
             self.fingertip_config.num_pts_y,
             self.fingertip_config.num_pts_z,

--- a/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
+++ b/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
@@ -120,6 +120,14 @@ class BatchDataInput:
         return self._nerf_alphas_with_coords_helper(self.coords)
 
     @property
+    def nerf_alphas_with_coords_v2(self) -> torch.Tensor:
+        return self._nerf_alphas_with_coords_v2_helper(
+            self.coords,
+            self.coords_wrt_wrist,
+            self.y_coords_wrt_table,
+        )
+
+    @property
     def nerf_alphas_with_augmented_coords(self) -> torch.Tensor:
         return self._nerf_alphas_with_coords_helper(self.augmented_coords)
 

--- a/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
+++ b/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
@@ -252,10 +252,19 @@ class BatchDataInput:
             NUM_XYZ,
         )
 
-        wrist_poses_wrt_object = pp.SE3(grasp_configs[..., :7])
+        assert grasp_configs[..., :7].shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            7,
+        )
+        wrist_poses_wrt_object = pp.SE3(grasp_configs[:, :, None, None, None, :7])
+
         assert wrist_poses_wrt_object.lshape == (
             self.batch_size,
             self.fingertip_config.n_fingers,
+            1,
+            1,
+            1,
         )
 
         T_wrist_object = wrist_poses_wrt_object.Inv()

--- a/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
+++ b/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
@@ -346,7 +346,7 @@ class BatchDataInput:
         )
         assert torch.all(self.object_y_wrt_table >= 0)
         y_coords_wrt_table = (
-            y_coords_wrt_object + self.object_y_wrt_table[..., None, None, None, None]
+            y_coords_wrt_object + self.object_y_wrt_table[..., None, None, None, None, None]
         )
         return y_coords_wrt_table
 

--- a/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
+++ b/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
@@ -51,6 +51,7 @@ class BatchDataInput:
     grasp_transforms: pp.LieTensor
     fingertip_config: BaseFingertipConfig  # have to take this because all these shape checks used to use hardcoded constants.
     grasp_configs: torch.Tensor
+    object_scales: torch.Tensor
     random_rotate_transform: Optional[pp.LieTensor] = None
     nerf_density_threshold_value: Optional[float] = None
 
@@ -63,6 +64,7 @@ class BatchDataInput:
             else None
         )
         self.grasp_configs = self.grasp_configs.to(device)
+        self.object_scales = self.object_scales.to(device)
         return self
 
     @property
@@ -96,12 +98,38 @@ class BatchDataInput:
         return self._coords_helper(self.augmented_grasp_transforms)
 
     @property
+    def coords_wrt_wrist(self) -> torch.Tensor:
+        return self._coords_wrt_wrist_helper(self.coords, self.grasp_configs)
+
+    @property
+    def augmented_coords_wrt_wrist(self) -> torch.Tensor:
+        return self._coords_wrt_wrist_helper(
+            self.augmented_coords, self.augmented_grasp_configs
+        )
+
+    @property
+    def y_coords_wrt_table(self) -> torch.Tensor:
+        return self._y_coords_wrt_table_helper(self.coords)
+
+    @property
+    def augmented_y_coords_wrt_table(self) -> torch.Tensor:
+        return self._y_coords_wrt_table_helper(self.augmented_coords)
+
+    @property
     def nerf_alphas_with_coords(self) -> torch.Tensor:
         return self._nerf_alphas_with_coords_helper(self.coords)
 
     @property
     def nerf_alphas_with_augmented_coords(self) -> torch.Tensor:
         return self._nerf_alphas_with_coords_helper(self.augmented_coords)
+
+    @property
+    def nerf_alphas_with_augmented_coords_v2(self) -> torch.Tensor:
+        return self._nerf_alphas_with_coords_v2_helper(
+            self.augmented_coords,
+            self.augmented_coords_wrt_wrist,
+            self.augmented_y_coords_wrt_table,
+        )
 
     @property
     def augmented_grasp_transforms(self) -> pp.LieTensor:
@@ -195,6 +223,88 @@ class BatchDataInput:
         )
         return all_query_points
 
+    def _coords_wrt_wrist_helper(
+        self, coords_wrt_object: torch.Tensor, grasp_configs: torch.Tensor
+    ) -> torch.Tensor:
+        assert coords_wrt_object.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        coords_wrt_object = coords_wrt_object.permute(0, 1, 3, 4, 5, 2)
+        assert coords_wrt_object.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+            NUM_XYZ,
+        )
+
+        wrist_poses_wrt_object = pp.SE3(grasp_configs[..., :7])
+        assert wrist_poses_wrt_object.lshape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+        )
+
+        T_wrist_object = wrist_poses_wrt_object.Inv()
+
+        coords_wrt_wrist = T_wrist_object @ coords_wrt_object
+        assert coords_wrt_wrist.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+            NUM_XYZ,
+        )
+        coords_wrt_wrist = coords_wrt_wrist.permute(0, 1, 5, 2, 3, 4)
+        assert coords_wrt_wrist.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+
+        return coords_wrt_wrist
+
+    def _y_coords_wrt_table_helper(
+        self, coords_wrt_object: torch.Tensor
+    ) -> torch.Tensor:
+        assert coords_wrt_object.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        y_coords_wrt_object = coords_wrt_object[:, :, 1:2]
+        assert y_coords_wrt_object.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            1,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+
+        # BRITTLE: hardcoding buffer and table thickness
+        BUFFER = 1.2
+        OBJ_MAX_EXTENT_FROM_ORIGIN = 1.0 * self.object_scales * BUFFER
+        TABLE_THICKNESS = 0.1
+        y_offset = OBJ_MAX_EXTENT_FROM_ORIGIN + TABLE_THICKNESS / 2
+        assert y_offset.shape == (self.batch_size,)
+        y_coords_wrt_table = (
+            y_coords_wrt_object + y_offset[..., None, None, None, None, None]
+        )
+        return y_coords_wrt_table
+
     def _nerf_alphas_with_coords_helper(self, coords: torch.Tensor) -> torch.Tensor:
         assert coords.shape == (
             self.batch_size,
@@ -223,6 +333,65 @@ class BatchDataInput:
             self.batch_size,
             self.fingertip_config.n_fingers,
             NUM_XYZ + 1,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        return return_value
+
+    def _nerf_alphas_with_coords_v2_helper(
+        self,
+        coords: torch.Tensor,
+        coords_wrt_wrist: torch.Tensor,
+        y_coords_wrt_table: torch.Tensor,
+    ) -> torch.Tensor:
+        NUM_Y = 1
+        assert coords.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        assert coords_wrt_wrist.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        assert y_coords_wrt_table.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_Y,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+
+        reshaped_nerf_alphas = self.nerf_alphas.reshape(
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            1,
+            self.fingertip_config.num_pts_x,
+            self.fingertip_config.num_pts_y,
+            self.fingertip_config.num_pts_z,
+        )
+        return_value = torch.cat(
+            [
+                reshaped_nerf_alphas,
+                coords,
+                coords_wrt_wrist,
+                y_coords_wrt_table,
+            ],
+            dim=2,
+        )
+        assert return_value.shape == (
+            self.batch_size,
+            self.fingertip_config.n_fingers,
+            NUM_XYZ + 1 + NUM_XYZ + NUM_Y,
             self.fingertip_config.num_pts_x,
             self.fingertip_config.num_pts_y,
             self.fingertip_config.num_pts_z,

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -504,6 +504,7 @@ def custom_collate_fn(
         grasp_transforms,
         nerf_configs,
         grasp_configs,
+        object_scales,
     ) = batch
 
     if debug_shuffle_labels:
@@ -533,6 +534,7 @@ def custom_collate_fn(
             fingertip_config=fingertip_config,
             nerf_density_threshold_value=nerf_density_threshold_value,
             grasp_configs=grasp_configs,
+            object_scales=object_scales,
         ),
         output=BatchDataOutput(
             passed_simulation=passed_simulation,
@@ -560,6 +562,7 @@ def depth_image_custom_collate_fn(
         grasp_transforms,
         nerf_configs,
         grasp_configs,
+        _,
     ) = batch
 
     if debug_shuffle_labels:

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -673,6 +673,7 @@ def print_shapes(batch_data: BatchData) -> None:
         print(
             f"nerf_alphas_with_coords.shape = {batch_data.input.nerf_alphas_with_coords.shape}"
         )
+        print(f"nerf_alphas_with_coords_v2.shape = {batch_data.input.nerf_alphas_with_coords_v2.shape}")
     elif isinstance(batch_data.input, DepthImageBatchDataInput):
         print(
             f"depth_uncertainty_images.shape: {batch_data.input.depth_uncertainty_images.shape}"

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -504,7 +504,7 @@ def custom_collate_fn(
         grasp_transforms,
         nerf_configs,
         grasp_configs,
-        object_scales,
+        object_y_wrt_table,
     ) = batch
 
     if debug_shuffle_labels:
@@ -534,7 +534,7 @@ def custom_collate_fn(
             fingertip_config=fingertip_config,
             nerf_density_threshold_value=nerf_density_threshold_value,
             grasp_configs=grasp_configs,
-            object_scales=object_scales,
+            object_y_wrt_table=object_y_wrt_table,
         ),
         output=BatchDataOutput(
             passed_simulation=passed_simulation,

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -1232,6 +1232,12 @@ def _iterate_through_dataloader(
                         batch_data.output.passed_simulation,
                         batch_data.output.passed_penetration_threshold,
                     ]
+                elif task_type == TaskType.PASSED_SIMULATION_AND_PENETRATION_THRESHOLD_AND_EVAL:
+                    task_targets = [
+                        batch_data.output.passed_simulation,
+                        batch_data.output.passed_penetration_threshold,
+                        batch_data.output.passed_eval,
+                    ]
                 else:
                     raise ValueError(f"Unknown task_type: {task_type}")
 
@@ -1388,6 +1394,7 @@ def _create_wandb_histogram_plot(
     ground_truths: List[float],
     predictions: List[float],
     title: str,
+    match_ylims: bool = False,
 ) -> wandb.Image:
     unique_labels = np.unique(ground_truths)
     fig, axes = plt.subplots(len(unique_labels), 1, figsize=(10, 10))
@@ -1411,9 +1418,10 @@ def _create_wandb_histogram_plot(
         axes[i].set_ylabel("Count")
 
     # Matching ylims
-    max_y_val = max(ax.get_ylim()[1] for ax in axes)
-    for i in range(len(axes)):
-        axes[i].set_ylim(0, max_y_val)
+    if match_ylims:
+        max_y_val = max(ax.get_ylim()[1] for ax in axes)
+        for i in range(len(axes)):
+            axes[i].set_ylim(0, max_y_val)
 
     fig.suptitle(title)
     fig.tight_layout()
@@ -1996,6 +2004,12 @@ elif cfg.task_type == TaskType.PASSED_SIMULATION_AND_PENETRATION_THRESHOLD:
     loss_fns = [
         passed_simulation_loss_fn,
         passed_penetration_threshold_loss_fn,
+    ]
+elif cfg.task_type == TaskType.PASSED_SIMULATION_AND_PENETRATION_THRESHOLD_AND_EVAL:
+    loss_fns = [
+        passed_simulation_loss_fn,
+        passed_penetration_threshold_loss_fn,
+        passed_eval_loss_fn,
     ]
 else:
     raise ValueError(f"Unknown task_type: {cfg.task_type}")

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -1685,7 +1685,7 @@ def get_class_from_success_rate(
 
 
 @localscope.mfc
-def _compute_class_weight(
+def _compute_class_weights_success_rates(
     success_rates: np.ndarray, unique_classes: np.ndarray
 ) -> np.ndarray:
     classes = np.arange(len(unique_classes))
@@ -1736,16 +1736,29 @@ def compute_class_weight_np(
     unique_passed_eval = get_unique_classes(passed_eval_np)
 
     # argmax required to make binary classes
-    passed_simulation_class_weight_np = _compute_class_weight(
-        success_rates=passed_simulations_np, unique_classes=unique_passed_simulations
-    )
-    passed_penetration_threshold_class_weight_np = _compute_class_weight(
-        success_rates=passed_penetration_threshold_np,
-        unique_classes=unique_passed_penetration_threshold,
-    )
-    passed_eval_class_weight_np = _compute_class_weight(
-        success_rates=passed_eval_np, unique_classes=unique_passed_eval
-    )
+    # passed_simulation_class_weight_np = _compute_class_weights_success_rates(
+    #     success_rates=passed_simulations_np, unique_classes=unique_passed_simulations
+    # )
+    # passed_penetration_threshold_class_weight_np = _compute_class_weights_success_rates(
+    #     success_rates=passed_penetration_threshold_np,
+    #     unique_classes=unique_passed_penetration_threshold,
+    # )
+    # passed_eval_class_weight_np = _compute_class_weights_success_rates(
+    #     success_rates=passed_eval_np, unique_classes=unique_passed_eval
+    # )
+
+    # With soft labels, the counts of labels are a bit weird
+    # Instead, let's say num of label 0 is sum(1 - label)
+    # and num of label 1 is sum(label)
+    # This would be same as count if we had hard labels
+    # class_weight = n_samples / (n_classes * np.bincount(y)) https://scikit-learn.org/stable/modules/generated/sklearn.utils.class_weight.compute_class_weight.html
+    assert passed_simulations_np.ndim == passed_penetration_threshold_np.ndim == passed_eval_np.ndim == 1
+    passed_simulation_class_weight_np = np.array([passed_simulations_np.shape[0] / (2 * (1 - passed_simulations_np).sum()),
+                                                  passed_simulations_np.shape[0] / (2 * passed_simulations_np.sum())])
+    passed_penetration_threshold_class_weight_np = np.array([passed_penetration_threshold_np.shape[0] / (2 * (1 - passed_penetration_threshold_np).sum()),
+                                                                passed_penetration_threshold_np.shape[0] / (2 * passed_penetration_threshold_np.sum())])
+    passed_eval_class_weight_np = np.array([passed_eval_np.shape[0] / (2 * (1 - passed_eval_np).sum()),
+                                            passed_eval_np.shape[0] / (2 * passed_eval_np.sum())])
     t6 = time.time()
     print(f"Computed class weight in {t6 - t5:.2f} s")
 

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -1332,7 +1332,7 @@ def _iterate_through_dataloader(
                         )
                     wandb.log(mid_epoch_log_dict)
 
-                loop_timer.pretty_print_section_times()
+                # loop_timer.pretty_print_section_times()
 
             # Set description
             if len(losses_dict["loss"]) > 0:

--- a/nerf_grasping/learned_metric/train_dataset.py
+++ b/nerf_grasping/learned_metric/train_dataset.py
@@ -113,6 +113,12 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
                 else None
             )
 
+            self.object_scales = (
+                torch.from_numpy(hdf5_file["/object_scale"][()]).float()
+                if False
+                else None
+            )
+
     def _set_length(
         self, hdf5_file: h5py.File, max_num_data_points: Optional[int]
     ) -> int:
@@ -203,6 +209,11 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
             if self.grasp_configs is None
             else self.grasp_configs[idx]
         )
+        object_scales = (
+            torch.from_numpy(self.hdf5_file["/object_scale"][idx]).float()
+            if self.object_scales is None
+            else self.object_scales[idx]
+        )
 
         assert_equals(
             nerf_densities.shape,
@@ -214,6 +225,7 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
         assert_equals(passed_eval.shape, (NUM_CLASSES,))
         assert_equals(grasp_transforms.shape, (self.NUM_FINGERS, 4, 4))
         assert_equals(grasp_configs.shape, (self.NUM_FINGERS, 7 + 16 + 4))
+        assert_equals(object_scales.shape, ())
 
         return (
             nerf_densities,
@@ -223,6 +235,7 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
             grasp_transforms,
             nerf_config,
             grasp_configs,
+            object_scales,
         )
 
     @property
@@ -354,6 +367,12 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
                 else None
             )
 
+            self.object_scales = (
+                torch.from_numpy(hdf5_file["/object_scale"][()]).float()
+                if False
+                else None
+            )
+
     def _set_length(
         self, hdf5_file: h5py.File, max_num_data_points: Optional[int]
     ) -> int:
@@ -452,6 +471,11 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
             if self.grasp_configs is None
             else self.grasp_configs[idx]
         )
+        object_scales = (
+            torch.from_numpy(self.hdf5_file["/object_scale"][idx]).float()
+            if self.object_scales is None
+            else self.object_scales[idx]
+        )
 
         assert_equals(
             depth_uncertainty_images.shape,
@@ -468,6 +492,7 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
         assert_equals(passed_eval.shape, (NUM_CLASSES,))
         assert_equals(grasp_transforms.shape, (self.NUM_FINGERS, 4, 4))
         assert_equals(grasp_configs.shape, (self.NUM_FINGERS, 7 + 16 + 4))
+        assert_equals(object_scales.shape, ())
 
         return (
             depth_uncertainty_images,
@@ -477,6 +502,7 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
             grasp_transforms,
             nerf_config,
             grasp_configs,
+            object_scales,
         )
 
     @property

--- a/nerf_grasping/learned_metric/train_dataset.py
+++ b/nerf_grasping/learned_metric/train_dataset.py
@@ -210,10 +210,10 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
             else self.grasp_configs[idx]
         )
         object_scales = (
-            torch.from_numpy(self.hdf5_file["/object_scale"][idx]).float()
+            torch.from_numpy(self.hdf5_file["/object_scale"][idx:idx+1]).float()
             if self.object_scales is None
-            else self.object_scales[idx]
-        )
+            else self.object_scales[idx:idx+1]
+        )[0]
 
         assert_equals(
             nerf_densities.shape,
@@ -472,10 +472,10 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
             else self.grasp_configs[idx]
         )
         object_scales = (
-            torch.from_numpy(self.hdf5_file["/object_scale"][idx]).float()
+            torch.from_numpy(self.hdf5_file["/object_scale"][idx:idx+1]).float()
             if self.object_scales is None
-            else self.object_scales[idx]
-        )
+            else self.object_scales[idx:idx+1]
+        )[0]
 
         assert_equals(
             depth_uncertainty_images.shape,

--- a/nerf_grasping/learned_metric/train_dataset.py
+++ b/nerf_grasping/learned_metric/train_dataset.py
@@ -113,8 +113,13 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
                 else None
             )
 
-            self.object_scales = (
+            self.object_scale = (
                 torch.from_numpy(hdf5_file["/object_scale"][()]).float()
+                if False
+                else None
+            )
+            self.object_state = (
+                torch.from_numpy(hdf5_file["/object_state"][()]).float()
                 if False
                 else None
             )
@@ -209,11 +214,16 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
             if self.grasp_configs is None
             else self.grasp_configs[idx]
         )
-        object_scales = (
+        object_scale = (
             torch.from_numpy(self.hdf5_file["/object_scale"][idx:idx+1]).float()
-            if self.object_scales is None
-            else self.object_scales[idx:idx+1]
+            if self.object_scale is None
+            else self.object_scale[idx:idx+1]
         )[0]
+        object_state = (
+            torch.from_numpy(self.hdf5_file["/object_state"][idx]).float()
+            if self.object_state is None
+            else self.object_state[idx]
+        )
 
         assert_equals(
             nerf_densities.shape,
@@ -225,7 +235,16 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
         assert_equals(passed_eval.shape, (NUM_CLASSES,))
         assert_equals(grasp_transforms.shape, (self.NUM_FINGERS, 4, 4))
         assert_equals(grasp_configs.shape, (self.NUM_FINGERS, 7 + 16 + 4))
-        assert_equals(object_scales.shape, ())
+        assert_equals(object_scale.shape, ())
+        assert_equals(object_state.shape, (13,))
+
+        # BRITTLE: hardcoding buffer, exclude table thickness, so this is wrt table surface
+        BUFFER = 1.2
+        OBJ_MAX_EXTENT_FROM_ORIGIN = 1.0 * object_scale * BUFFER
+        y_offset = OBJ_MAX_EXTENT_FROM_ORIGIN
+        object_y = object_state[1]
+        object_y_wrt_table = y_offset - object_y
+        assert object_y_wrt_table >= 0
 
         return (
             nerf_densities,
@@ -235,7 +254,7 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
             grasp_transforms,
             nerf_config,
             grasp_configs,
-            object_scales,
+            object_y_wrt_table,
         )
 
     @property
@@ -367,8 +386,13 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
                 else None
             )
 
-            self.object_scales = (
+            self.object_scale = (
                 torch.from_numpy(hdf5_file["/object_scale"][()]).float()
+                if False
+                else None
+            )
+            self.object_state = (
+                torch.from_numpy(hdf5_file["/object_state"][()]).float()
                 if False
                 else None
             )
@@ -471,11 +495,16 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
             if self.grasp_configs is None
             else self.grasp_configs[idx]
         )
-        object_scales = (
+        object_scale = (
             torch.from_numpy(self.hdf5_file["/object_scale"][idx:idx+1]).float()
-            if self.object_scales is None
-            else self.object_scales[idx:idx+1]
+            if self.object_scale is None
+            else self.object_scale[idx:idx+1]
         )[0]
+        object_state = (
+            torch.from_numpy(self.hdf5_file["/object_state"][idx]).float()
+            if self.object_state is None
+            else self.object_state[idx]
+        )
 
         assert_equals(
             depth_uncertainty_images.shape,
@@ -492,7 +521,15 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
         assert_equals(passed_eval.shape, (NUM_CLASSES,))
         assert_equals(grasp_transforms.shape, (self.NUM_FINGERS, 4, 4))
         assert_equals(grasp_configs.shape, (self.NUM_FINGERS, 7 + 16 + 4))
-        assert_equals(object_scales.shape, ())
+        assert_equals(object_scale.shape, ())
+
+        # BRITTLE: hardcoding buffer, exclude table thickness, so this is wrt table surface
+        BUFFER = 1.2
+        OBJ_MAX_EXTENT_FROM_ORIGIN = 1.0 * object_scale * BUFFER
+        y_offset = OBJ_MAX_EXTENT_FROM_ORIGIN
+        object_y = object_state[1]
+        object_y_wrt_table = y_offset - object_y
+        assert object_y_wrt_table >= 0
 
         return (
             depth_uncertainty_images,
@@ -502,7 +539,7 @@ class DepthImage_To_GraspSuccess_HDF5_Dataset(Dataset):
             grasp_transforms,
             nerf_config,
             grasp_configs,
-            object_scales,
+            object_y_wrt_table,
         )
 
     @property

--- a/nerf_grasping/nerf_utils.py
+++ b/nerf_grasping/nerf_utils.py
@@ -208,7 +208,7 @@ def compute_centroid_from_nerf(
     field: Field,
     lb: np.ndarray,
     ub: np.ndarray,
-    level: int,
+    level: float,
     num_pts_x: int,
     num_pts_y: int,
     num_pts_z: int,

--- a/nerf_grasping/nerf_utils.py
+++ b/nerf_grasping/nerf_utils.py
@@ -1,21 +1,28 @@
 """
 Utils for rendering depth / uncertainty images from the NeRF.
 """
+
 from nerf_grasping.config.camera_config import CameraConfig
 from nerfstudio.cameras.cameras import Cameras, CameraType
 from nerfstudio.cameras.rays import RayBundle
 from nerfstudio.models.base_model import Model
+from nerfstudio.fields.base_field import Field
 from nerfstudio.data.scene_box import SceneBox
 from collections import defaultdict
 import numpy as np
 import pypose as pp
 import torch
 from typing import Literal, Dict, Tuple
+from nerf_grasping.dataset.DexGraspNet_NeRF_Grasps_utils import (
+    get_ray_samples_in_region,
+)
 
 GRASP_TO_OPENCV = pp.euler2SO3([np.pi, 0, 0]).unsqueeze(0)
 
+
 def assert_equals(a, b):
     assert a == b, f"{a} != {b}"
+
 
 def get_cameras(
     grasp_transforms: pp.LieTensor,
@@ -114,7 +121,9 @@ def get_ray_samples(
 
 
 def _render_depth_and_uncertainty_for_camera_ray_bundle(
-    nerf_model: Model, camera_ray_bundle: RayBundle, depth_mode: Literal["median", "expected"]
+    nerf_model: Model,
+    camera_ray_bundle: RayBundle,
+    depth_mode: Literal["median", "expected"],
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Takes in camera parameters and computes the output of the model.
 
@@ -193,3 +202,64 @@ def _render_depth_and_uncertainty_for_single_ray_bundle(
         raise ValueError(f"Invalid depth mode {depth_mode}")
 
     return depth, depth_variance
+
+
+def compute_centroid_from_nerf(
+    field: Field,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    level: int,
+    num_pts_x: int,
+    num_pts_y: int,
+    num_pts_z: int,
+) -> np.ndarray:
+    """
+    Compute the centroid of the field.
+    """
+    x_min, y_min, z_min = lb
+    x_max, y_max, z_max = ub
+    ray_samples_in_region = get_ray_samples_in_region(
+        x_min=x_min,
+        x_max=x_max,
+        y_min=y_min,
+        y_max=y_max,
+        z_min=z_min,
+        z_max=z_max,
+        num_pts_x=num_pts_x,
+        num_pts_y=num_pts_y,
+        num_pts_z=num_pts_z,
+    )
+    query_points_in_region = np.copy(
+        ray_samples_in_region.frustums.get_positions()
+        .cpu()
+        .numpy()
+        .reshape(
+            num_pts_x,
+            num_pts_y,
+            num_pts_z,
+            3,
+        )
+    )
+    nerf_densities_in_region = (
+        field.get_density(ray_samples_in_region.to("cuda"))[0]
+        .detach()
+        .cpu()
+        .numpy()
+        .reshape(
+            num_pts_x,
+            num_pts_y,
+            num_pts_z,
+        )
+    )
+
+    points_to_keep_with_nans = np.where(
+        (nerf_densities_in_region > 15)[..., None].repeat(3, axis=-1),
+        query_points_in_region,
+        np.nan,
+    )
+    # Check there are some non-nan
+    assert not np.all(np.isnan(points_to_keep_with_nans))
+
+    avg_point_no_nans = np.nanmean(points_to_keep_with_nans.reshape(-1, 3), axis=0)
+    assert avg_point_no_nans.shape == (3,)
+    return avg_point_no_nans

--- a/nerf_grasping/nerfstudio_train/train_nerfs.py
+++ b/nerf_grasping/nerfstudio_train/train_nerfs.py
@@ -42,8 +42,11 @@ def train_nerfs(args: Args) -> pathlib.Path:
 
     if args.randomize_order_seed is not None:
         import random
+
         print(f"Randomizing order with seed {args.randomize_order_seed}")
-        random.Random(args.randomize_order_seed).shuffle(object_and_scale_nerfdata_paths)
+        random.Random(args.randomize_order_seed).shuffle(
+            object_and_scale_nerfdata_paths
+        )
 
     for object_and_scale_nerfdata_path in tqdm(
         object_and_scale_nerfdata_paths, dynamic_ncols=True, desc="Training NERF"
@@ -66,7 +69,11 @@ def train_nerfs(args: Args) -> pathlib.Path:
                 f"--output-dir {str(output_nerfcheckpoints_path)}",
                 "--vis wandb",
                 "--pipeline.model.disable-scene-contraction True",
-                ("--pipeline.model.background-color black" if not args.is_real_world else ""),
+                (
+                    "--pipeline.model.background-color black"
+                    if not args.is_real_world
+                    else ""
+                ),
                 "nerfstudio-data",
                 "--auto-scale-poses False",
                 "--scale-factor 1.",
@@ -76,7 +83,7 @@ def train_nerfs(args: Args) -> pathlib.Path:
             ]
         )
         print_and_run(command)
-
+    return output_nerfcheckpoints_path
 
 
 def main() -> None:
@@ -85,6 +92,7 @@ def main() -> None:
     print(f"{pathlib.Path(__file__).name} args: {args}")
     print("=" * 80 + "\n")
     return train_nerfs(args)
+
 
 if __name__ == "__main__":
     main()

--- a/nerf_grasping/nerfstudio_train/train_nerfs.py
+++ b/nerf_grasping/nerfstudio_train/train_nerfs.py
@@ -25,12 +25,7 @@ def print_and_run(cmd: str) -> None:
     subprocess.run(cmd, shell=True, check=True)
 
 
-def main() -> None:
-    args = tyro.cli(Args)
-    print("=" * 80)
-    print(f"{pathlib.Path(__file__).name} args: {args}")
-    print("=" * 80 + "\n")
-
+def train_nerfs(args: Args) -> pathlib.Path:
     assert (
         args.nerf_grasping_data_path.exists()
     ), f"{args.nerf_grasping_data_path} does not exist"
@@ -82,6 +77,14 @@ def main() -> None:
         )
         print_and_run(command)
 
+
+
+def main() -> None:
+    args = tyro.cli(Args)
+    print("=" * 80)
+    print(f"{pathlib.Path(__file__).name} args: {args}")
+    print("=" * 80 + "\n")
+    return train_nerfs(args)
 
 if __name__ == "__main__":
     main()

--- a/nerf_grasping/nerfstudio_train/train_nerfs.py
+++ b/nerf_grasping/nerfstudio_train/train_nerfs.py
@@ -15,6 +15,7 @@ class Args:
     nerf_grasping_data_path: pathlib.Path = (
         pathlib.Path(nerf_grasping.get_repo_root()).resolve() / "data"
     )
+    is_real_world: bool = False
 
 
 def print_and_run(cmd: str) -> None:
@@ -61,11 +62,11 @@ def main() -> None:
                 f"--output-dir {str(output_nerfcheckpoints_path)}",
                 "--vis wandb",
                 "--pipeline.model.disable-scene-contraction True",
-                "--pipeline.model.background-color black",
+                ("--pipeline.model.background-color black" if not args.is_real_world else ""),
                 "nerfstudio-data",
                 "--auto-scale-poses False",
                 "--scale-factor 1.",
-                "--scene-scale 0.2",
+                ("--scene-scale 0.2" if not args.is_real_world else "--scene-scale 1."),
                 "--center-method none",
                 "--orientation-method none",
             ]

--- a/nerf_grasping/nerfstudio_train/train_nerfs.py
+++ b/nerf_grasping/nerfstudio_train/train_nerfs.py
@@ -4,6 +4,7 @@ import pathlib
 from dataclasses import dataclass
 import nerf_grasping
 from tqdm import tqdm
+from typing import Optional
 
 
 @dataclass
@@ -16,6 +17,7 @@ class Args:
         pathlib.Path(nerf_grasping.get_repo_root()).resolve() / "data"
     )
     is_real_world: bool = False
+    randomize_order_seed: Optional[int] = None
 
 
 def print_and_run(cmd: str) -> None:
@@ -41,8 +43,15 @@ def main() -> None:
     output_nerfcheckpoints_path = experiment_path / args.output_nerfcheckpoints_name
     output_nerfcheckpoints_path.mkdir(exist_ok=True)
 
+    object_and_scale_nerfdata_paths = sorted(list(nerfdata_path.iterdir()))
+
+    if args.randomize_order_seed is not None:
+        import random
+        print(f"Randomizing order with seed {args.randomize_order_seed}")
+        random.Random(args.randomize_order_seed).shuffle(object_and_scale_nerfdata_paths)
+
     for object_and_scale_nerfdata_path in tqdm(
-        nerfdata_path.iterdir(), dynamic_ncols=True, desc="Training NERF"
+        object_and_scale_nerfdata_paths, dynamic_ncols=True, desc="Training NERF"
     ):
         if not object_and_scale_nerfdata_path.is_dir():
             continue

--- a/nerf_grasping/nerfstudio_train/train_nerfs.py
+++ b/nerf_grasping/nerfstudio_train/train_nerfs.py
@@ -91,7 +91,7 @@ def main() -> None:
     print("=" * 80)
     print(f"{pathlib.Path(__file__).name} args: {args}")
     print("=" * 80 + "\n")
-    return train_nerfs(args)
+    train_nerfs(args)
 
 
 if __name__ == "__main__":

--- a/nerf_grasping/nerfstudio_train/train_nerfs_return_trainer.py
+++ b/nerf_grasping/nerfstudio_train/train_nerfs_return_trainer.py
@@ -2,20 +2,7 @@ from dataclasses import dataclass
 import pathlib
 
 from nerfstudio.scripts.train import _set_random_seed
-from nerfstudio.engine.trainer import TrainerConfig
-
-from nerfstudio.cameras.camera_optimizers import CameraOptimizerConfig
-from nerfstudio.configs.base_config import ViewerConfig
-
-from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManagerConfig
-from nerfstudio.data.dataparsers.nerfstudio_dataparser import NerfstudioDataParserConfig
-from nerfstudio.engine.optimizers import AdamOptimizerConfig
-from nerfstudio.engine.schedulers import (
-    ExponentialDecaySchedulerConfig,
-)
 from nerfstudio.engine.trainer import TrainerConfig, Trainer
-from nerfstudio.models.nerfacto import NerfactoModelConfig
-from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
 
 
 @dataclass
@@ -47,44 +34,9 @@ def train_loop_return_trainer(
 
 def get_nerfacto_default_config():
     # From nerfstudio/configs/method_configs.py nerfacto
-    return TrainerConfig(
-        method_name="nerfacto",
-        steps_per_eval_batch=500,
-        steps_per_save=2000,
-        max_num_iterations=30000,
-        mixed_precision=True,
-        pipeline=VanillaPipelineConfig(
-            datamanager=VanillaDataManagerConfig(
-                dataparser=NerfstudioDataParserConfig(),
-                train_num_rays_per_batch=4096,
-                eval_num_rays_per_batch=4096,
-                camera_optimizer=CameraOptimizerConfig(
-                    mode="SO3xR3",
-                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                    scheduler=ExponentialDecaySchedulerConfig(
-                        lr_final=6e-6, max_steps=200000
-                    ),
-                ),
-            ),
-            model=NerfactoModelConfig(eval_num_rays_per_chunk=1 << 15),
-        ),
-        optimizers={
-            "proposal_networks": {
-                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-                "scheduler": ExponentialDecaySchedulerConfig(
-                    lr_final=0.0001, max_steps=200000
-                ),
-            },
-            "fields": {
-                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
-                "scheduler": ExponentialDecaySchedulerConfig(
-                    lr_final=0.0001, max_steps=200000
-                ),
-            },
-        },
-        viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
-        vis="viewer",
-    )
+    from nerfstudio.configs.method_configs import all_methods
+
+    return all_methods["nerfacto"]
 
 
 def train_nerf(
@@ -112,6 +64,10 @@ def train_nerf(
 
     # Need to set timestamp
     config.set_timestamp()
+
+    # print and save config
+    config.print_to_terminal()
+    config.save_config()
 
     trainer = train_loop_return_trainer(local_rank=0, world_size=1, config=config)
     return trainer

--- a/nerf_grasping/nerfstudio_train/train_nerfs_return_trainer.py
+++ b/nerf_grasping/nerfstudio_train/train_nerfs_return_trainer.py
@@ -1,0 +1,134 @@
+from dataclasses import dataclass
+import pathlib
+
+from nerfstudio.scripts.train import _set_random_seed
+from nerfstudio.engine.trainer import TrainerConfig
+
+from nerfstudio.cameras.camera_optimizers import CameraOptimizerConfig
+from nerfstudio.configs.base_config import ViewerConfig
+
+from nerfstudio.data.datamanagers.base_datamanager import VanillaDataManagerConfig
+from nerfstudio.data.dataparsers.nerfstudio_dataparser import NerfstudioDataParserConfig
+from nerfstudio.engine.optimizers import AdamOptimizerConfig
+from nerfstudio.engine.schedulers import (
+    ExponentialDecaySchedulerConfig,
+)
+from nerfstudio.engine.trainer import TrainerConfig, Trainer
+from nerfstudio.models.nerfacto import NerfactoModelConfig
+from nerfstudio.pipelines.base_pipeline import VanillaPipelineConfig
+
+
+@dataclass
+class Args:
+    nerfdata_folder: pathlib.Path
+    nerfcheckpoints_folder: pathlib.Path
+    max_num_iterations: int = 200
+    is_real_world: bool = False
+
+
+def train_loop_return_trainer(
+    local_rank: int, world_size: int, config: TrainerConfig, global_rank: int = 0
+) -> Trainer:
+    """Main training function that sets up and runs the trainer per process
+    THIS IS A COPY OF train_loop in https://github.com/nerfstudio-project/nerfstudio/blob/main/nerfstudio/scripts/train.py
+    BUT RETURNS THE TRAINER
+
+    Args:
+        local_rank: current rank of process
+        world_size: total number of gpus available
+        config: config file specifying training regimen
+    """
+    _set_random_seed(config.machine.seed + global_rank)
+    trainer = config.setup(local_rank=local_rank, world_size=world_size)
+    trainer.setup()
+    trainer.train()
+    return trainer
+
+
+def get_nerfacto_default_config():
+    # From nerfstudio/configs/method_configs.py nerfacto
+    return TrainerConfig(
+        method_name="nerfacto",
+        steps_per_eval_batch=500,
+        steps_per_save=2000,
+        max_num_iterations=30000,
+        mixed_precision=True,
+        pipeline=VanillaPipelineConfig(
+            datamanager=VanillaDataManagerConfig(
+                dataparser=NerfstudioDataParserConfig(),
+                train_num_rays_per_batch=4096,
+                eval_num_rays_per_batch=4096,
+                camera_optimizer=CameraOptimizerConfig(
+                    mode="SO3xR3",
+                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
+                    scheduler=ExponentialDecaySchedulerConfig(
+                        lr_final=6e-6, max_steps=200000
+                    ),
+                ),
+            ),
+            model=NerfactoModelConfig(eval_num_rays_per_chunk=1 << 15),
+        ),
+        optimizers={
+            "proposal_networks": {
+                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
+                "scheduler": ExponentialDecaySchedulerConfig(
+                    lr_final=0.0001, max_steps=200000
+                ),
+            },
+            "fields": {
+                "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
+                "scheduler": ExponentialDecaySchedulerConfig(
+                    lr_final=0.0001, max_steps=200000
+                ),
+            },
+        },
+        viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
+        vis="viewer",
+    )
+
+
+def train_nerf(
+    args: Args,
+) -> Trainer:
+    config = get_nerfacto_default_config()
+
+    # Modifications
+    config.data = args.nerfdata_folder
+    config.pipeline.datamanager.data = args.nerfdata_folder
+    config.max_num_iterations = args.max_num_iterations
+    config.output_dir = args.nerfcheckpoints_folder
+    config.vis = "wandb"
+    config.pipeline.model.disable_scene_contraction = True
+    config.pipeline.model.background_color = (
+        "black" if not args.is_real_world else "last_sample"
+    )
+    config.pipeline.datamanager.dataparser.auto_scale_poses = False
+    config.pipeline.datamanager.dataparser.scale_factor = 1.0
+    config.pipeline.datamanager.dataparser.scene_scale = (
+        0.2 if not args.is_real_world else 1.0
+    )
+    config.pipeline.datamanager.dataparser.center_method = "none"
+    config.pipeline.datamanager.dataparser.orientation_method = "none"
+
+    # Need to set timestamp
+    config.set_timestamp()
+
+    trainer = train_loop_return_trainer(local_rank=0, world_size=1, config=config)
+    return trainer
+
+
+def main() -> None:
+    args = Args(
+        nerfdata_folder=pathlib.Path(
+            "experiments/2024-04-15_DEBUG/nerfdata/sem-Vase-3a275e00d69810c62600e861c93ad9cc_0_0846"
+        ),
+        nerfcheckpoints_folder=pathlib.Path(
+            "experiments/2024-04-15_DEBUG/nerfcheckpoints/"
+        ),
+        is_real_world=False,
+    )
+    train_nerf(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/nerf_grasping/optimizer.py
+++ b/nerf_grasping/optimizer.py
@@ -412,12 +412,16 @@ def get_optimized_grasps(cfg: OptimizationConfig) -> Dict[str, np.ndarray]:
             cfg.init_grasp_config_dict_path, allow_pickle=True
         ).item()
 
+        # HACK: For now, just take every 400th grasp.
+        # for key in init_grasp_config_dict.keys():
+        #     init_grasp_config_dict[key] = init_grasp_config_dict[key][::400]
+
         init_grasp_configs = AllegroGraspConfig.from_grasp_config_dict(
             init_grasp_config_dict
         )
 
-        # init_grasp_configs = init_grasp_configs[: cfg.optimizer.num_grasps]
         # HACK: For now, just take the first num_grasps.
+        # init_grasp_configs = init_grasp_configs[: cfg.optimizer.num_grasps]
 
         if progress is not None and task is not None:
             progress.update(task, advance=1)
@@ -455,6 +459,7 @@ def get_optimized_grasps(cfg: OptimizationConfig) -> Dict[str, np.ndarray]:
             all_preds = np.concatenate(all_preds, axis=0)
             assert all_preds.shape[0] == init_grasp_configs.batch_size
             ordered_idxs_best_first = np.argsort(all_preds)[::-1].copy()
+            breakpoint()
             init_grasp_configs = init_grasp_configs[ordered_idxs_best_first]
         breakpoint()
     init_grasp_configs = init_grasp_configs[:cfg.optimizer.num_grasps]

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -655,14 +655,14 @@ class GraspMetric(torch.nn.Module):
             self.fingertip_config.num_pts_z,
         )
 
-        # HACK
-        raise NotImplementedError("Need to implement this object scale")
+        # HACK: NOT SURE HOW TO FILL THIS
+        # raise NotImplementedError("Need to implement this object scale")
         batch_data_input = BatchDataInput(
             nerf_densities=densities,
             grasp_transforms=grasp_config.grasp_frame_transforms,
             fingertip_config=self.fingertip_config,
             grasp_configs=grasp_config.as_tensor(),
-            object_y_wrt_table=None,  # ?
+            object_y_wrt_table=None,  # ? NEED TO PASS THIS IN?
         ).to(grasp_config.hand_config.wrist_pose.device)
 
         # Pass grasp transforms, densities into classifier.

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -672,11 +672,14 @@ class GraspMetric(torch.nn.Module):
             self.fingertip_config.num_pts_z,
         )
 
+        # HACK
+        raise NotImplementedError("Need to implement this object scale")
         batch_data_input = BatchDataInput(
             nerf_densities=densities,
             grasp_transforms=grasp_config.grasp_frame_transforms,
             fingertip_config=self.fingertip_config,
             grasp_configs=grasp_config.as_tensor(),
+            object_scales=1,
         ).to(grasp_config.hand_config.wrist_pose.device)
 
         # Pass grasp transforms, densities into classifier.

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -77,6 +77,9 @@ class AllegroHandConfig(torch.nn.Module):
         )
         self.batch_size = batch_size
 
+    def __len__(self) -> int:
+        return self.batch_size
+
     @classmethod
     def from_values(
         cls,
@@ -245,6 +248,9 @@ class AllegroGraspConfig(torch.nn.Module):
             requires_grad=requires_grad,
         )
         self.num_fingers = num_fingers
+
+    def __len__(self) -> int:
+        return self.batch_size
 
     @classmethod
     def from_path(cls, path: pathlib.Path) -> AllegroGraspConfig:
@@ -604,13 +610,13 @@ class GraspMetric(torch.nn.Module):
         # TODO: Batch this to avoid OOM (refer to Create_DexGraspNet_NeRF_Grasps_Dataset.py)
 
         # HACK
-        self.object_transform_world_frame = np.array(
-            [[1.0000, 0.0000, 0.0000, 0.0262],
-             [0.0000, 0.0000, -1.0000, -0.0067],
-                [0.0000, 1.0000, 0.0000, 0.1244],
-                [0.0000, 0.0000, 0.0000, 1.0000]
-            ]
-        )
+        # self.object_transform_world_frame = np.array(
+        #     [[1.0000, 0.0000, 0.0000, 0.0262],
+        #      [0.0000, 0.0000, -1.0000, -0.0067],
+        #         [0.0000, 1.0000, 0.0000, 0.1244],
+        #         [0.0000, 0.0000, 0.0000, 1.0000]
+        #     ]
+        # )
 # array([[ 1.00000000e+00,  0.00000000e+00,  0.00000000e+00,
 #          2.61625908e-02],
 #        [ 0.00000000e+00,  2.22044605e-16, -1.00000000e+00,

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -679,7 +679,7 @@ class GraspMetric(torch.nn.Module):
             grasp_transforms=grasp_config.grasp_frame_transforms,
             fingertip_config=self.fingertip_config,
             grasp_configs=grasp_config.as_tensor(),
-            object_scales=1,
+            object_y_wrt_table=None,  # ?
         ).to(grasp_config.hand_config.wrist_pose.device)
 
         # Pass grasp transforms, densities into classifier.

--- a/prepare_dgn_experiment.py
+++ b/prepare_dgn_experiment.py
@@ -16,6 +16,8 @@ class Args:
     frac_val: float = 0.1
     random_seed: Optional[int] = None
     train_nerfs: bool = False
+    create_grid_dataset: bool = False
+    create_depth_image_dataset: bool = False
 
     dgn_data_path: pathlib.Path = pathlib.Path(
         "~/github_repos/DexGraspNet/data"
@@ -126,48 +128,50 @@ def main() -> None:
         )
 
     # Create grid dataset
-    print_and_run(
-        f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
-        + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_train'}"
-        + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
-        + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'train_dataset.h5'}"
-    )
-    if n_val > 0:
+    if args.create_grid_dataset:
         print_and_run(
             f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
-            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_val'}"
+            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_train'}"
             + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
-            + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'val_dataset.h5'}"
+            + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'train_dataset.h5'}"
         )
-    if n_test > 0:
-        print_and_run(
-            f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
-            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_test'}"
-            + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
-            + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'test_dataset.h5'}"
-        )
+        if n_val > 0:
+            print_and_run(
+                f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_val'}"
+                + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
+                + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'val_dataset.h5'}"
+            )
+        if n_test > 0:
+            print_and_run(
+                f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_test'}"
+                + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
+                + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'test_dataset.h5'}"
+            )
 
     # Create depth_image dataset
-    print_and_run(
-        f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
-        + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_train'}"
-        + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
-        + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'train_dataset.h5'}"
-    )
-    if n_val > 0:
+    if args.create_depth_image_dataset:
         print_and_run(
             f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
-            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_val'}"
+            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_train'}"
             + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
-            + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'val_dataset.h5'}"
+            + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'train_dataset.h5'}"
         )
-    if n_test > 0:
-        print_and_run(
-            f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
-            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_test'}"
-            + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
-            + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'test_dataset.h5'}"
-        )
+        if n_val > 0:
+            print_and_run(
+                f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_val'}"
+                + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
+                + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'val_dataset.h5'}"
+            )
+        if n_test > 0:
+            print_and_run(
+                f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_test'}"
+                + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
+                + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'test_dataset.h5'}"
+            )
 
 
 if __name__ == "__main__":

--- a/rough_hardware_deployment_code.py
+++ b/rough_hardware_deployment_code.py
@@ -1,49 +1,182 @@
 from nerf_grasping.optimizer import get_optimized_grasps as TYLER_get_optimized_grasps
-from nerf_grasping.optimizer_utils import get_sorted_grasps_from_dict as TYLER_get_sorted_grasps_from_dict
+from nerf_grasping.optimizer_utils import (
+    get_sorted_grasps_from_dict as TYLER_get_sorted_grasps_from_dict,
+)
 from nerf_grasping.config.optimization_config import OptimizationConfig
 from nerf_grasping.config.optimizer_config import SGDOptimizerConfig
 from nerf_grasping.config.grasp_metric_config import GraspMetricConfig
+from nerf_grasping.nerfstudio_train import train_nerfs
+from nerf_grasping.baselines.nerf_to_mesh import nerf_to_mesh
+import trimesh
+import nerf_grasping
 import pathlib
+import tyro
+import numpy as np
+from dataclasses import dataclass
+from nerf_grasping.grasp_utils import (
+    get_nerf_configs,
+    load_nerf_pipeline,
+)
 
-nerf_data = ALBERT_run_hardware_nerf_data_collection()
-nerf_checkpoint_path = ALBERT_run_hardware_nerf_training(nerf_data)
-object_transform_world_frame = get_object_transform_world_frame(nerf_data)
 
-assert nerf_checkpoint_path.exists(), f"{nerf_checkpoint_path} does not exist"
-assert nerf_checkpoint_path.suffix == ".yml", f"{nerf_checkpoint_path} is not a .yml file"
-assert object_transform_world_frame.shape == (4, 4), f"object_transform_world_frame.shape is {object_transform_world_frame.shape}, not (4, 4)"
+@dataclass
+class Args:
+    experiment_name: str
+    init_grasp_config_dict_path: pathlib.Path
+    classifier_config_path: pathlib.Path
 
-INIT_GRASP_CONFIG_DICT_PATH = pathlib.Path("/path/to/init.npy")
-NERF_CHECKPOINT_PATH = pathlib.Path("/path/to/nerfcheckpoints/config.yml")
-CLASSIFIER_CONFIG_PATH = pathlib.Path("/path/to/classifier/config.yml")
+    def __post_init__(self) -> None:
+        assert (
+            self.init_grasp_config_dict_path.exists()
+        ), f"{self.init_grasp_config_dict_path} does not exist"
+        assert (
+            self.classifier_config_path.exists()
+        ), f"{self.classifier_config_path} does not exist"
 
-optimized_grasp_config_dict = TYLER_get_optimized_grasps(
-    OptimizationConfig(
-        use_rich=True,
-        init_grasp_config_dict_path=INIT_GRASP_CONFIG_DICT_PATH,
-        grasp_metric=GraspMetricConfig(
-            nerf_checkpoint_path=nerf_checkpoint_path,
-            classifier_config_path=CLASSIFIER_CONFIG_PATH,
-            object_transform_world_frame=object_transform_world_frame,
-        ),
-        optimizer=SGDOptimizerConfig(),
+        assert (
+            self.init_grasp_config_dict_path.is_file()
+        ), f"{self.init_grasp_config_dict_path} is not a file"
+        assert (
+            self.classifier_config_path.is_file()
+        ), f"{self.classifier_config_path} is not a file"
+
+        assert self.init_grasp_config_dict_path.suffix == ".npy"(
+            f"{self.init_grasp_config_dict_path} does not have a .npy suffix"
+        )
+        assert self.classifier_config_path.suffix in [
+            ".yml",
+            ".yaml",
+        ], f"{self.classifier_config_path} does not have a .yml or .yaml suffix"
+
+
+def rough_hardware_deployment_code(args: Args) -> None:
+    print("=" * 80)
+    print("Step 0: Figuring out frames")
+    print("=" * 80 + "\n")
+    print("Frames are W = world, N = nerf, O = object, Oy = object y-up, H = hand")
+    print(
+        "W is centered at the robot base. N is centered where origin of NeRF data collection is. O is centered at the object centroid. Oy is centered at the object centroid. H is centered at the base of the middle finger"
     )
-)
-wrist_trans, wrist_rot, joint_angles, target_joint_angles = TYLER_get_sorted_grasps_from_dict(
-    optimized_grasp_config_dict=optimized_grasp_config_dict,
-    object_transform_world_frame=object_transform_world_frame,
-    error_if_no_loss=False,
-    check=True,
-    print_best=True,
-)
+    print(
+        "W, N, O are z-up frames. Oy is y-up. H has z-up along finger and x-up along palm normal"
+    )
+    print("X_A_B represents 4x4 transformation matrix of frame B wrt A")
+    X_W_N = trimesh.transformations.translation_matrix([0.7, 0, 0])  # TODO: Check this
 
-num_grasps = wrist_trans.shape[0]
+    print("\n" + "=" * 80)
+    print("Step 1: Collect NERF data")
+    print("=" * 80 + "\n")
+    nerfdata_folder = pathlib.Path(f"{args.experiment_name}/nerfdata")
+    nerfdata_folder.mkdir(parents=True, exist_ok=False)
+    nerf_data = ALBERT_run_hardware_nerf_data_collection(nerfdata_folder)
+    assert nerfdata_folder.exists(), f"{nerfdata_folder} does not exist"
 
-for i in range(num_grasps):
-    print(f"Trying grasp {i} / {num_grasps}")
+    print("\n" + "=" * 80)
+    print("Step 2: Train NERF")
+    print("=" * 80 + "\n")
+    nerf_checkpoint_path = train_nerfs.train_nerfs(
+        train_nerfs.Args(
+            experiment_name=args.experiment_name,
+            nerf_grasping_data_path=pathlib.Path(
+                nerf_grasping.get_repo_root()
+            ).resolve()
+            / "data",
+            is_real_world=True,
+        )
+    )
+    assert nerf_checkpoint_path.exists(), f"{nerf_checkpoint_path} does not exist"
 
-    if not ALBERT_is_feasible(wrist_trans[i], wrist_rot[i], joint_angles[i]):
-        print(f"Grasp {i} is infeasible")
-        continue
+    print("\n" + "=" * 80)
+    print("Step 3: Load NERF")
+    print("=" * 80 + "\n")
+    nerf_configs = get_nerf_configs(str(nerf_checkpoint_path))
+    assert len(nerf_configs) == 1, f"len(nerf_configs) is {len(nerf_configs)}, not 1"
+    nerf_pipeline = load_nerf_pipeline(nerf_configs[0])
 
-    ALBERT_execute_grasp(wrist_trans[i], wrist_rot[i], joint_angles[i], target_joint_angles[i])
+    print("\n" + "=" * 80)
+    print("Step 3: Convert NeRF to mesh")
+    print("=" * 80 + "\n")
+    mesh = nerf_to_mesh(
+        field=nerf_pipeline.model.field,
+        level=15,
+        lb=np.array([-0.25, 0.25, 0.0]),
+        ub=np.array([0.25, 0.25, 0.3]),
+    )  # TODO: Maybe tune other default params, but prefer not to need to
+
+    print("\n" + "=" * 80)
+    print(
+        "Step 4: Compute X_N_Oy (transformation of the object y-up frame wrt the nerf frame)"
+    )
+    X_O_Oy = trimesh.transformations.rotation_matrix(
+        np.pi / 2, [1, 0, 0]
+    )  # TODO: Check this
+
+    USE_MESH = True
+    if USE_MESH:
+        centroid = mesh.centroid
+    else:
+        centroid = compute_centroid_from_nerf(nerf_pipeline.model.field)
+    assert centroid.shape == (3,), f"centroid.shape is {centroid.shape}, not (3,)"
+    X_N_O = trimesh.transformations.translation_matrix(centroid)  # TODO: Check this
+
+    X_N_Oy = X_N_O @ X_O_Oy
+    assert X_N_Oy.shape == (4, 4), f"X_N_Oy.shape is {X_N_Oy.shape}, not (4, 4)"
+
+    print("\n" + "=" * 80)
+    print("Step 5: Load grasp metric and init grasps, optimize")
+    print("=" * 80 + "\n")
+    optimized_grasp_config_dict = TYLER_get_optimized_grasps(
+        OptimizationConfig(
+            use_rich=True,
+            init_grasp_config_dict_path=args.init_grasp_config_dict_path,
+            grasp_metric=GraspMetricConfig(
+                nerf_checkpoint_path=nerf_checkpoint_path,
+                classifier_config_path=args.classifier_config_path,
+                X_N_Oy=X_N_Oy,
+            ),
+            optimizer=SGDOptimizerConfig(),
+        )
+    )
+
+    print("\n" + "=" * 80)
+    print("Step 6: Compute best grasps in W frame")
+    X_Oy_H_array, joint_angles_array, target_joint_angles_array = (
+        TYLER_get_sorted_grasps_from_dict(
+            optimized_grasp_config_dict=optimized_grasp_config_dict,
+            X_N_Oy=X_N_Oy,
+            error_if_no_loss=False,
+            check=True,
+            print_best=True,
+        )
+    )
+    num_grasps = X_Oy_H_array.shape[0]
+    assert X_Oy_H_array.shape == (num_grasps, 4, 4)
+    assert joint_angles_array.shape == (num_grasps, 16)
+    assert target_joint_angles_array.shape == (num_grasps, 16)
+
+    for i in range(num_grasps):
+        print(f"Trying grasp {i} / {num_grasps}")
+
+        X_Oy_H = X_Oy_H_array[i]
+        joint_angles = joint_angles_array[i]
+        target_joint_angles = target_joint_angles_array[i]
+
+        X_W_H = X_W_N @ X_N_Oy @ X_Oy_H
+
+        if not ALBERT_is_feasible(X_Oy_H, joint_angles):
+            print(f"Grasp {i} is infeasible")
+            continue
+
+        ALBERT_execute_grasp(X_W_H, joint_angles, target_joint_angles)
+
+
+def main() -> None:
+    args = tyro.cli(Args)
+    print("=" * 80)
+    print(f"{pathlib.Path(__file__).name} args: {args}")
+    print("=" * 80 + "\n")
+    return rough_hardware_deployment_code(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/rough_hardware_deployment_code.py
+++ b/rough_hardware_deployment_code.py
@@ -128,7 +128,7 @@ def rough_hardware_deployment_code(args: Args) -> None:
     print(
         "Step 4: Compute X_N_Oy (transformation of the object y-up frame wrt the nerf frame)"
     )
-    USE_MESH = True
+    USE_MESH = False
     mesh_centroid = mesh.centroid
     nerf_centroid = compute_centroid_from_nerf(
         nerf_pipeline.model.field,

--- a/rough_hardware_deployment_code.py
+++ b/rough_hardware_deployment_code.py
@@ -93,7 +93,7 @@ def rough_hardware_deployment_code(args: Args) -> None:
     nerfdata_folder = pathlib.Path(f"{args.experiment_name}/nerfdata")
     if not nerfdata_folder.exists():
         nerfdata_folder.mkdir(parents=True)
-        ALBERT_run_hardware_nerf_data_collection(nerfdata_folder)
+        ALBERT_run_hardware_nerf_data_collection(nerfdata_folder, args.object_name)
         assert nerfdata_folder.exists(), f"{nerfdata_folder} does not exist"
     else:
         print(f"{nerfdata_folder} already exists, skipping data collection")

--- a/rough_hardware_deployment_code.py
+++ b/rough_hardware_deployment_code.py
@@ -78,13 +78,11 @@ def rough_hardware_deployment_code(args: Args) -> None:
             np.pi / 2, [1, 0, 0]
         )  # TODO: Check this
         lb_N = np.array([-0.25, -0.25, 0.0])
-        ub_N = np.array([0.25, 0.25, 0.3])
+        ub_N = np.array([0.25, 0.25, 0.5])
     else:
-        X_O_Oy = trimesh.transformations.rotation_matrix(
-            0, [1, 0, 0]
-        )  # TODO: Check this
-        lb_N = np.array([-0.25, 0.0, -0.25])
-        ub_N = np.array([0.25, 0.3, 0.25])
+        X_O_Oy = np.eye(4)
+        lb_N = np.array([-0.25, -0.25, -0.25])
+        ub_N = np.array([0.25, 0.25, 0.25])
 
     experiment_folder = args.experiments_folder / args.experiment_name
     print(f"Creating a new experiment folder at {experiment_folder}")
@@ -110,7 +108,7 @@ def rough_hardware_deployment_code(args: Args) -> None:
         args=train_nerfs_return_trainer.Args(
             nerfdata_folder=object_nerfdata_folder,
             nerfcheckpoints_folder=experiment_folder / "nerfcheckpoints",
-            is_real_world=False,
+            is_real_world=args.is_real_world,
         )
     )
     nerf_model = nerf_trainer.pipeline.model

--- a/rough_hardware_deployment_code.py
+++ b/rough_hardware_deployment_code.py
@@ -1,7 +1,5 @@
-from nerf_grasping.optimizer import get_optimized_grasps as TYLER_get_optimized_grasps
-from nerf_grasping.optimizer_utils import (
-    get_sorted_grasps_from_dict as TYLER_get_sorted_grasps_from_dict,
-)
+from nerf_grasping.optimizer import get_optimized_grasps
+from nerf_grasping.optimizer_utils import get_sorted_grasps_from_dict
 from nerf_grasping.config.optimization_config import OptimizationConfig
 from nerf_grasping.config.optimizer_config import SGDOptimizerConfig
 from nerf_grasping.config.grasp_metric_config import GraspMetricConfig
@@ -135,7 +133,7 @@ def rough_hardware_deployment_code(args: Args) -> None:
     print("\n" + "=" * 80)
     print("Step 5: Load grasp metric and init grasps, optimize")
     print("=" * 80 + "\n")
-    optimized_grasp_config_dict = TYLER_get_optimized_grasps(
+    optimized_grasp_config_dict = get_optimized_grasps(
         OptimizationConfig(
             use_rich=True,
             init_grasp_config_dict_path=args.init_grasp_config_dict_path,
@@ -144,16 +142,21 @@ def rough_hardware_deployment_code(args: Args) -> None:
                 classifier_config_path=args.classifier_config_path,
                 X_N_Oy=X_N_Oy,
             ),
-            optimizer=SGDOptimizerConfig(),
+            optimizer=SGDOptimizerConfig(
+                num_grasps=32,
+                num_steps=200,
+                finger_lr=1e-4,
+                grasp_dir_lr=1e-4,
+                wrist_lr=1e-4,
+            ),
         )
     )
 
     print("\n" + "=" * 80)
     print("Step 6: Compute best grasps in W frame")
     X_Oy_H_array, joint_angles_array, target_joint_angles_array = (
-        TYLER_get_sorted_grasps_from_dict(
+        get_sorted_grasps_from_dict(
             optimized_grasp_config_dict=optimized_grasp_config_dict,
-            X_N_Oy=X_N_Oy,
             error_if_no_loss=False,
             check=True,
             print_best=True,
@@ -185,7 +188,7 @@ def main() -> None:
     print("=" * 80)
     print(f"{pathlib.Path(__file__).name} args: {args}")
     print("=" * 80 + "\n")
-    return rough_hardware_deployment_code(args)
+    rough_hardware_deployment_code(args)
 
 
 if __name__ == "__main__":

--- a/rough_hardware_deployment_code.py
+++ b/rough_hardware_deployment_code.py
@@ -157,7 +157,7 @@ def rough_hardware_deployment_code(args: Args) -> None:
     assert X_N_Oy.shape == (4, 4), f"X_N_Oy.shape is {X_N_Oy.shape}, not (4, 4)"
 
     print("\n" + "=" * 80)
-    print("Step 5: Load grasp metric and init grasps, optimize")
+    print("Step 5: Load grasp metric")
     print("=" * 80 + "\n")
     print(f"Loading classifier config from {args.classifier_config_path}")
     classifier_config = tyro.extras.from_yaml(
@@ -185,6 +185,9 @@ def rough_hardware_deployment_code(args: Args) -> None:
             X_N_Oy=X_N_Oy,
         )
 
+    print("\n" + "=" * 80)
+    print("Step 6: Optimize grasps")
+    print("=" * 80 + "\n")
     optimized_grasp_config_dict = get_optimized_grasps(
         cfg=OptimizationConfig(
             use_rich=True,
@@ -211,7 +214,7 @@ def rough_hardware_deployment_code(args: Args) -> None:
     )
 
     print("\n" + "=" * 80)
-    print("Step 6: Compute best grasps in W frame")
+    print("Step 7: Convert optimized grasps to joint angles")
     print("=" * 80 + "\n")
     X_Oy_H_array, joint_angles_array, target_joint_angles_array = (
         get_sorted_grasps_from_dict(
@@ -227,7 +230,7 @@ def rough_hardware_deployment_code(args: Args) -> None:
     assert target_joint_angles_array.shape == (num_grasps, 16)
 
     print("\n" + "=" * 80)
-    print("Step 7: Execute best grasps")
+    print("Step 8: Execute best grasps")
     print("=" * 80 + "\n")
     for i in range(num_grasps):
         print(f"Trying grasp {i} / {num_grasps}")


### PR DESCRIPTION
Changes:
* Improve interface with `get_sorted_grasps_from_file` to return transformation matrices X_Oy_H (transformation matrix of hand frame wrt object yup frame)
* return mesh when run nerf_to_mesh
* When optimizing, assume it should use the last prediction task, not the product of them all
* Add CNN_3D_XYZY, CNN_3D_XYZXYZ, CNN_3D_XYZXYZY to include positions wrt wrist and wrt table y
* Add task type with all 3 labels
* No max num data points per file
* Sort filepaths before running create data h5 script
* Store object state in h5
* Fix memory leak issue with nerf pipeline but putting the IO loading nerf pipeline in a function, not global scope and add memory printing 
* Add ability to get ray samples for a box region
* Add object_y_wrt_table optional param in BatchDataInput, will error if not given AND it is used
* Add histogram to wandb
* Set class weights based on 0 and 1 summing just 2 classes, not all unique soft labels
* Store object scale and object state in the torch dataset to be used for table position computation
* Hacky table y computation brittle
* Add `compute_centroid_from_nerf`
* Add is_real_world option for train_nerfs.py
* Add `nerf_grasping/nerfstudio_train/train_nerfs_return_trainer.py` to return trainer to nerf doens't need to be loaded again in hardware script
* Add option to give grasp_metric directly to get_optimized_grasps instead of loading it from scratch
* Add hacky way of getting best grasp by evaling them all
* Rename object_transform_world_frame to X_N_Oy
* Create compute_ray_samples and compute_nerf_densities methods for GraspMetric for better debugging
* TODO:             object_y_wrt_table=None,  # ? NEED TO PASS THIS IN? assumes it is not used
* When prepare_dgn_experiment.py add option to choose if create_grid and/or create_depth_image datasets
* Revamp and flesh out rough_hardware_deployment_code.py