### PR TITLE
2024 05 07 warmup better

### DIFF
--- a/nerf_grasping/baselines/nerf_to_mesh.py
+++ b/nerf_grasping/baselines/nerf_to_mesh.py
@@ -61,7 +61,7 @@ def nerf_to_mesh(
     lb: np.ndarray = -np.ones(3),
     ub: np.ndarray = np.ones(3),
     scale: float = 1.0,
-    min_len: Optional[float] = None,
+    min_len: Optional[float] = 200,  # Default 200 to get rid of floaters
     flip_faces: bool = True,
     save_path: Optional[Path] = None,
 ) -> trimesh.Trimesh:

--- a/nerf_grasping/curobo_fr3_algr_zed2i/fr3_algr_zed2i_world.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/fr3_algr_zed2i_world.py
@@ -49,6 +49,7 @@ def get_world_cfg(
     obj_xyz: Tuple[float, float, float] = (0.65, 0.0, 0.0),
     obj_quat_wxyz: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
     collision_check_table: bool = True,
+    obj_name: str = "object",
 ) -> WorldConfig:
     world_dict = {}
     if collision_check_table:

--- a/nerf_grasping/curobo_fr3_algr_zed2i/fr3_algr_zed2i_world.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/fr3_algr_zed2i_world.py
@@ -62,6 +62,7 @@ def get_world_cfg(
             )
         )
     if len(world_dict) == 0:
+        # Error if there are no objects, so add a dummy object
         world_dict.update(get_dummy_collision_dict())
     world_cfg = WorldConfig.from_dict(world_dict)
     return world_cfg

--- a/nerf_grasping/curobo_fr3_algr_zed2i/fr3_algr_zed2i_world.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/fr3_algr_zed2i_world.py
@@ -18,10 +18,11 @@ def get_object_collision_dict(
     file_path: pathlib.Path,
     xyz: Tuple[float, float, float],
     quat_wxyz: Tuple[float, float, float, float],
+    obj_name: str = "object",
 ) -> dict:
     return {
         "mesh": {
-            "object": {
+            obj_name: {
                 "pose": [*xyz, *quat_wxyz],
                 "file_path": str(file_path),
             }
@@ -57,7 +58,7 @@ def get_world_cfg(
     if collision_check_object and obj_filepath is not None:
         world_dict.update(
             get_object_collision_dict(
-                file_path=obj_filepath, xyz=obj_xyz, quat_wxyz=obj_quat_wxyz
+                file_path=obj_filepath, xyz=obj_xyz, quat_wxyz=obj_quat_wxyz, obj_name=obj_name
             )
         )
     if len(world_dict) == 0:

--- a/nerf_grasping/curobo_fr3_algr_zed2i/ik_fr3_algr_zed2i.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/ik_fr3_algr_zed2i.py
@@ -20,64 +20,7 @@ from nerf_grasping.curobo_fr3_algr_zed2i.fr3_algr_zed2i_world import (
 from nerf_grasping.curobo_fr3_algr_zed2i.joint_limit_utils import (
     modify_robot_cfg_to_add_joint_limit_buffer,
 )
-import torch.nn.functional as F
-
-
-def _sqrt_positive_part(x: torch.Tensor) -> torch.Tensor:
-    """
-    Returns torch.sqrt(torch.max(0, x))
-    subgradient is zero where x is 0.
-    """
-    ret = torch.zeros_like(x)
-    positive_mask = x > 0
-    ret[positive_mask] = torch.sqrt(x[positive_mask])
-    return ret
-
-
-def matrix_to_quat_wxyz(matrix: torch.Tensor) -> torch.Tensor:
-    """
-    Convert rotations given as rotation matrices to quat_wxyz.
-    Args:
-        matrix: Rotation matrices as tensor of shape (..., 3, 3).
-    Returns:
-        quat_wxyz with real part first, as tensor of shape (..., 4).
-    """
-    if matrix.size(-1) != 3 or matrix.size(-2) != 3:
-        raise ValueError(f"Invalid rotation matrix shape {matrix.shape}.")
-
-    batch_dim = matrix.shape[:-2]
-    m00, m01, m02, m10, m11, m12, m20, m21, m22 = torch.unbind(
-        matrix.reshape(batch_dim + (9,)), dim=-1
-    )
-
-    q_abs = _sqrt_positive_part(
-        torch.stack(
-            [
-                1.0 + m00 + m11 + m22,
-                1.0 + m00 - m11 - m22,
-                1.0 - m00 + m11 - m22,
-                1.0 - m00 - m11 + m22,
-            ],
-            dim=-1,
-        )
-    )
-
-    quat_by_rijk = torch.stack(
-        [
-            torch.stack([q_abs[..., 0] ** 2, m21 - m12, m02 - m20, m10 - m01], dim=-1),
-            torch.stack([m21 - m12, q_abs[..., 1] ** 2, m10 + m01, m02 + m20], dim=-1),
-            torch.stack([m02 - m20, m10 + m01, q_abs[..., 2] ** 2, m12 + m21], dim=-1),
-            torch.stack([m10 - m01, m20 + m02, m21 + m12, q_abs[..., 3] ** 2], dim=-1),
-        ],
-        dim=-2,
-    )
-
-    flr = torch.tensor(0.1).to(dtype=q_abs.dtype, device=q_abs.device)
-    quat_candidates = quat_by_rijk / (2.0 * q_abs[..., None].max(flr))
-
-    return quat_candidates[
-        F.one_hot(q_abs.argmax(dim=-1), num_classes=4) > 0.5, :
-    ].reshape(batch_dim + (4,))
+from nerf_grasping.curobo_fr3_algr_zed2i.math_utils import matrix_to_quat_wxyz
 
 
 def solve_iks(

--- a/nerf_grasping/curobo_fr3_algr_zed2i/math_utils.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/math_utils.py
@@ -1,0 +1,88 @@
+import torch
+import torch.nn.functional as F
+
+
+def _sqrt_positive_part(x: torch.Tensor) -> torch.Tensor:
+    """
+    Returns torch.sqrt(torch.max(0, x))
+    subgradient is zero where x is 0.
+    """
+    ret = torch.zeros_like(x)
+    positive_mask = x > 0
+    ret[positive_mask] = torch.sqrt(x[positive_mask])
+    return ret
+
+
+def matrix_to_quat_wxyz(matrix: torch.Tensor) -> torch.Tensor:
+    """
+    Convert rotations given as rotation matrices to quat_wxyz.
+    Args:
+        matrix: Rotation matrices as tensor of shape (..., 3, 3).
+    Returns:
+        quat_wxyz with real part first, as tensor of shape (..., 4).
+    """
+    if matrix.size(-1) != 3 or matrix.size(-2) != 3:
+        raise ValueError(f"Invalid rotation matrix shape {matrix.shape}.")
+
+    batch_dim = matrix.shape[:-2]
+    m00, m01, m02, m10, m11, m12, m20, m21, m22 = torch.unbind(
+        matrix.reshape(batch_dim + (9,)), dim=-1
+    )
+
+    q_abs = _sqrt_positive_part(
+        torch.stack(
+            [
+                1.0 + m00 + m11 + m22,
+                1.0 + m00 - m11 - m22,
+                1.0 - m00 + m11 - m22,
+                1.0 - m00 - m11 + m22,
+            ],
+            dim=-1,
+        )
+    )
+
+    quat_by_rijk = torch.stack(
+        [
+            torch.stack([q_abs[..., 0] ** 2, m21 - m12, m02 - m20, m10 - m01], dim=-1),
+            torch.stack([m21 - m12, q_abs[..., 1] ** 2, m10 + m01, m02 + m20], dim=-1),
+            torch.stack([m02 - m20, m10 + m01, q_abs[..., 2] ** 2, m12 + m21], dim=-1),
+            torch.stack([m10 - m01, m20 + m02, m21 + m12, q_abs[..., 3] ** 2], dim=-1),
+        ],
+        dim=-2,
+    )
+
+    flr = torch.tensor(0.1).to(dtype=q_abs.dtype, device=q_abs.device)
+    quat_candidates = quat_by_rijk / (2.0 * q_abs[..., None].max(flr))
+
+    return quat_candidates[
+        F.one_hot(q_abs.argmax(dim=-1), num_classes=4) > 0.5, :
+    ].reshape(batch_dim + (4,))
+
+
+def quat_wxyz_to_matrix(quat_wxyzs: torch.Tensor) -> torch.Tensor:
+    """
+    Convert rotations given as quat_wxyzs to rotation matrices.
+    Args:
+        quat_wxyzs: quaternions with real part first,
+            as tensor of shape (..., 4).
+    Returns:
+        Rotation matrices as tensor of shape (..., 3, 3).
+    """
+    r, i, j, k = torch.unbind(quat_wxyzs, -1)
+    two_s = 2.0 / (quat_wxyzs * quat_wxyzs).sum(-1)
+
+    mat = torch.stack(
+        (
+            1 - two_s * (j * j + k * k),
+            two_s * (i * j - k * r),
+            two_s * (i * k + j * r),
+            two_s * (i * j + k * r),
+            1 - two_s * (i * i + k * k),
+            two_s * (j * k - i * r),
+            two_s * (i * k - j * r),
+            two_s * (j * k + i * r),
+            1 - two_s * (i * i + j * j),
+        ),
+        -1,
+    )
+    return mat.reshape(quat_wxyzs.shape[:-1] + (3, 3))

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -4,7 +4,6 @@ from typing import Optional, Tuple, List
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 
 from curobo.cuda_robot_model.cuda_robot_model import (
     CudaRobotModel,
@@ -42,63 +41,9 @@ from nerf_grasping.optimizer_utils import (
     is_in_limits,
 )
 
-
-def _sqrt_positive_part(x: torch.Tensor) -> torch.Tensor:
-    """
-    Returns torch.sqrt(torch.max(0, x))
-    subgradient is zero where x is 0.
-    """
-    ret = torch.zeros_like(x)
-    positive_mask = x > 0
-    ret[positive_mask] = torch.sqrt(x[positive_mask])
-    return ret
-
-
-def matrix_to_quat_wxyz(matrix: torch.Tensor) -> torch.Tensor:
-    """
-    Convert rotations given as rotation matrices to quat_wxyz.
-    Args:
-        matrix: Rotation matrices as tensor of shape (..., 3, 3).
-    Returns:
-        quat_wxyz with real part first, as tensor of shape (..., 4).
-    """
-    if matrix.size(-1) != 3 or matrix.size(-2) != 3:
-        raise ValueError(f"Invalid rotation matrix shape {matrix.shape}.")
-
-    batch_dim = matrix.shape[:-2]
-    m00, m01, m02, m10, m11, m12, m20, m21, m22 = torch.unbind(
-        matrix.reshape(batch_dim + (9,)), dim=-1
-    )
-
-    q_abs = _sqrt_positive_part(
-        torch.stack(
-            [
-                1.0 + m00 + m11 + m22,
-                1.0 + m00 - m11 - m22,
-                1.0 - m00 + m11 - m22,
-                1.0 - m00 - m11 + m22,
-            ],
-            dim=-1,
-        )
-    )
-
-    quat_by_rijk = torch.stack(
-        [
-            torch.stack([q_abs[..., 0] ** 2, m21 - m12, m02 - m20, m10 - m01], dim=-1),
-            torch.stack([m21 - m12, q_abs[..., 1] ** 2, m10 + m01, m02 + m20], dim=-1),
-            torch.stack([m02 - m20, m10 + m01, q_abs[..., 2] ** 2, m12 + m21], dim=-1),
-            torch.stack([m10 - m01, m20 + m02, m21 + m12, q_abs[..., 3] ** 2], dim=-1),
-        ],
-        dim=-2,
-    )
-
-    flr = torch.tensor(0.1).to(dtype=q_abs.dtype, device=q_abs.device)
-    quat_candidates = quat_by_rijk / (2.0 * q_abs[..., None].max(flr))
-
-    return quat_candidates[
-        F.one_hot(q_abs.argmax(dim=-1), num_classes=4) > 0.5, :
-    ].reshape(batch_dim + (4,))
-
+from nerf_grasping.curobo_fr3_algr_zed2i.math_utils import (
+    matrix_to_quat_wxyz,
+)
 
 def debug_start_state_invalid(
     motion_gen_config: MotionGenConfig,

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -169,6 +169,7 @@ def prepare_solve_trajopt_batch(
         num_batch_ik_seeds=1,  # Reduced to save time?
         num_batch_trajopt_seeds=1,  # Reduced to save time?
         num_trajopt_noisy_seeds=1,  # Reduced to save time?
+        collision_cache={"obb": 2, "mesh": 2},
     )
     motion_gen = MotionGen(motion_gen_config)
 

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -150,6 +150,232 @@ def debug_start_state_invalid(
         print("mask.all() == True")
 
 
+def prepare_solve_trajopt_batch(
+    collision_check_object: bool = True,
+    obj_filepath: Optional[pathlib.Path] = pathlib.Path(
+        "/juno/u/tylerlum/github_repos/nerf_grasping/experiments/2024-05-02_16-19-22/nerf_to_mesh/mug_330/coacd/decomposed.obj"
+    ),
+    obj_xyz: Tuple[float, float, float] = (0.65, 0.0, 0.0),
+    obj_quat_wxyz: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+    collision_check_table: bool = True,
+    use_cuda_graph: bool = True,
+    collision_sphere_buffer: Optional[float] = None,
+) -> Tuple[RobotConfig, IKSolver, IKSolver, MotionGen, MotionGenConfig]:
+    start_time = time.time()
+
+    tensor_args = TensorDeviceType()
+    robot_file = "fr3_algr_zed2i_with_fingertips.yml"
+    robot_cfg = load_yaml(join_path(get_robot_configs_path(), robot_file))["robot_cfg"]
+    if collision_sphere_buffer is not None:
+        robot_cfg["kinematics"]["collision_sphere_buffer"] = collision_sphere_buffer
+    robot_cfg = RobotConfig.from_dict(robot_cfg)
+    modify_robot_cfg_to_add_joint_limit_buffer(robot_cfg)
+
+    world_cfg = get_world_cfg(
+        collision_check_object=collision_check_object,
+        obj_filepath=obj_filepath,
+        obj_xyz=obj_xyz,
+        obj_quat_wxyz=obj_quat_wxyz,
+        collision_check_table=collision_check_table,
+    )
+
+    ik_config = IKSolverConfig.load_from_robot_config(
+        robot_cfg,
+        world_cfg,
+        rotation_threshold=0.01,
+        position_threshold=0.001,
+        num_seeds=20,
+        self_collision_check=True,
+        self_collision_opt=True,
+        tensor_args=tensor_args,
+        use_cuda_graph=use_cuda_graph,
+    )
+    ik_solver = IKSolver(ik_config)
+
+    ik_config2 = IKSolverConfig.load_from_robot_config(
+        robot_cfg,
+        world_cfg,
+        rotation_threshold=0.05,
+        position_threshold=0.005,
+        num_seeds=20,
+        self_collision_check=True,
+        self_collision_opt=True,
+        tensor_args=tensor_args,
+        use_cuda_graph=use_cuda_graph,
+    )
+    ik_solver2 = IKSolver(ik_config2)
+
+    print("Step 6: Solve motion generation")
+    motion_gen_config = MotionGenConfig.load_from_robot_config(
+        robot_cfg,
+        world_cfg,
+        tensor_args,
+        collision_checker_type=CollisionCheckerType.MESH,
+        use_cuda_graph=use_cuda_graph,
+        num_ik_seeds=1,  # Reduced to save time?
+        num_graph_seeds=1,  # Reduced to save time?
+        num_trajopt_seeds=1,  # Reduced to save time?
+        num_batch_ik_seeds=1,  # Reduced to save time?
+        num_batch_trajopt_seeds=1,  # Reduced to save time?
+        num_trajopt_noisy_seeds=1,  # Reduced to save time?
+    )
+    motion_gen = MotionGen(motion_gen_config)
+    # motion_gen.warmup(batch=N_GRASPS)  # Can cause issues with CUDA graph
+
+    end_time = time.time()
+    print(f"Total time taken: {end_time - start_time} seconds")
+
+    return robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config
+
+
+def new_solve_trajopt_batch(
+    X_W_Hs: np.ndarray,
+    q_algrs: np.ndarray,
+    robot_cfg: RobotConfig,
+    ik_solver: IKSolver,
+    ik_solver2: IKSolver,
+    motion_gen: MotionGen,
+    motion_gen_config: MotionGenConfig,
+    q_fr3_starts: Optional[np.ndarray] = None,
+    q_algr_starts: Optional[np.ndarray] = None,
+    enable_graph: bool = True,
+    enable_opt: bool = False,  # Getting some errors from setting this to True
+    timeout: float = 5.0,
+) -> Tuple[MotionGenResult, IKResult, IKResult]:
+    N_GRASPS = X_W_Hs.shape[0]
+    assert X_W_Hs.shape == (N_GRASPS, 4, 4), f"X_W_Hs.shape: {X_W_Hs.shape}"
+    assert q_algrs.shape == (N_GRASPS, 16), f"q_algrs.shape: {q_algrs.shape}"
+    assert is_in_limits(q_algrs).all(), f"q_algrs: {q_algrs}"
+
+    if q_fr3_starts is None:
+        print("Using default q_fr3_starts")
+        q_fr3_starts = DEFAULT_Q_FR3[None, ...].repeat(N_GRASPS, axis=0)
+    assert q_fr3_starts.shape == (
+        N_GRASPS,
+        7,
+    ), f"q_fr3_starts.shape: {q_fr3_starts.shape}"
+    if q_algr_starts is None:
+        print("Using default q_algr_starts")
+        q_algr_starts = DEFAULT_Q_ALGR[None, ...].repeat(N_GRASPS, axis=0)
+    assert q_algr_starts.shape == (
+        N_GRASPS,
+        16,
+    ), f"q_algr_starts.shape: {q_algr_starts.shape}"
+
+    trans = X_W_Hs[:, :3, 3]
+    rot_matrix = X_W_Hs[:, :3, :3]
+    quat_wxyz = matrix_to_quat_wxyz(torch.from_numpy(rot_matrix).float().cuda())
+
+    target_pose = Pose(
+        torch.from_numpy(trans).float().cuda(),
+        quaternion=quat_wxyz,
+    )
+
+    ik_result = ik_solver.solve_batch(target_pose)
+
+    kin_model = CudaRobotModel(robot_cfg.kinematics)
+    q_fr3s = ik_result.solution[..., :7].squeeze(dim=1).detach().cpu().numpy()
+    q = torch.from_numpy(np.concatenate([q_fr3s, q_algrs], axis=1)).float().cuda()
+    assert q.shape == (N_GRASPS, 23)
+    state = kin_model.get_state(q)
+
+    ik_result2 = ik_solver2.solve_batch(
+        goal_pose=target_pose, link_poses=state.link_pose
+    )
+
+    kin_model2 = CudaRobotModel(robot_cfg.kinematics)
+    q2 = ik_result2.solution.squeeze(dim=1)
+
+    assert q2.shape == (N_GRASPS, 23)
+    state2 = kin_model2.get_state(q2)
+
+    q_starts = (
+        torch.from_numpy(
+            np.concatenate(
+                [
+                    q_fr3_starts,
+                    q_algr_starts,
+                ],
+                axis=1,
+            )
+        )
+        .float()
+        .cuda()
+    )
+    # Can't succeed in motion planning if joint limits are violated
+    CHECK_JOINT_LIMITS = True
+    if CHECK_JOINT_LIMITS:
+        joint_limits = robot_cfg.kinematics.kinematics_config.joint_limits.position
+        assert joint_limits.shape == (2, 23)
+        joint_lower_limits, joint_upper_limits = joint_limits[0], joint_limits[1]
+        if (q_starts < joint_lower_limits[None]).any() or (
+            q_starts > joint_upper_limits[None]
+        ).any():
+            print("#" * 80)
+            print("q_starts out of joint limits!")
+            print("#" * 80)
+            print(
+                f"q_starts = {q_starts}, joint_lower_limits = {joint_lower_limits}, joint_upper_limits = {joint_upper_limits}"
+            )
+            print(
+                f"q_starts < joint_lower_limits = {(q_starts < joint_lower_limits[None]).any()}"
+            )
+            print(
+                f"q_starts > joint_upper_limits = {(q_starts > joint_upper_limits[None]).any()}"
+            )
+            print(
+                f"(q_starts < joint_lower_limits[None]).nonzero() = {(q_starts < joint_lower_limits[None]).nonzero()}"
+            )
+            print(
+                f"(q_starts > joint_upper_limits[None]).nonzero() = {(q_starts > joint_upper_limits[None]).nonzero()}"
+            )
+
+            # HACK: Check if out of joint limits due to small numerical issues
+            eps = 1e-4
+            if (q_starts > joint_lower_limits[None] - eps).all() and (
+                q_starts < joint_upper_limits[None] + eps
+            ).all():
+                print(
+                    f"q_starts is close to joint limits within {eps}, so clamping to limits with some margin"
+                )
+                q_starts = torch.clamp(
+                    q_starts,
+                    joint_lower_limits[None] + eps,
+                    joint_upper_limits[None] - eps,
+                )
+            else:
+                print("q_starts is far from joint limits, so not clamping")
+                raise ValueError("q_starts out of joint limits!")
+
+    start_state = JointState.from_position(q_starts)
+
+    DEBUG_START_STATE_INVALID = False
+    if DEBUG_START_STATE_INVALID:
+        debug_start_state_invalid(
+            motion_gen_config=motion_gen_config, start_state=start_state
+        )
+
+    target_pose2 = Pose(
+        state2.ee_position,
+        quaternion=state2.ee_quaternion,
+    )
+    motion_result = motion_gen.plan_batch(
+        start_state=start_state,
+        goal_pose=target_pose2,
+        plan_config=MotionGenPlanConfig(
+            enable_graph=enable_graph,
+            enable_opt=enable_opt,
+            # max_attempts=10,
+            max_attempts=1,  # Reduce to save time?
+            num_trajopt_seeds=1,  # Reduce to save time?
+            num_graph_seeds=1,  # Must be 1 for plan_batch
+            timeout=timeout,
+        ),
+        link_poses=state2.link_pose,
+    )
+    return motion_result, ik_result, ik_result2
+
+
 def solve_trajopt_batch(
     X_W_Hs: np.ndarray,
     q_algrs: np.ndarray,
@@ -162,7 +388,7 @@ def solve_trajopt_batch(
     obj_xyz: Tuple[float, float, float] = (0.65, 0.0, 0.0),
     obj_quat_wxyz: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
     collision_check_table: bool = True,
-    use_cuda_graph: bool = True,  # Getting some errors from setting this to True
+    use_cuda_graph: bool = True,
     enable_graph: bool = True,
     enable_opt: bool = False,  # Getting some errors from setting this to True
     timeout: float = 5.0,

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -151,6 +151,7 @@ def debug_start_state_invalid(
 
 
 def prepare_solve_trajopt_batch(
+    n_grasps: int,
     collision_check_object: bool = True,
     obj_filepath: Optional[pathlib.Path] = pathlib.Path(
         "/juno/u/tylerlum/github_repos/nerf_grasping/experiments/2024-05-02_16-19-22/nerf_to_mesh/mug_330/coacd/decomposed.obj"
@@ -220,7 +221,7 @@ def prepare_solve_trajopt_batch(
         num_trajopt_noisy_seeds=1,  # Reduced to save time?
     )
     motion_gen = MotionGen(motion_gen_config)
-    # motion_gen.warmup(batch=N_GRASPS)  # Can cause issues with CUDA graph
+    motion_gen.warmup(batch=n_grasps)  # Can cause issues with CUDA graph
 
     end_time = time.time()
     print(f"Total time taken: {end_time - start_time} seconds")

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -126,6 +126,7 @@ def prepare_solve_trajopt_batch(
         obj_xyz=obj_xyz,
         obj_quat_wxyz=obj_quat_wxyz,
         collision_check_table=collision_check_table,
+        obj_name="MY_object",
     )
 
     # ik_solver

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -105,7 +105,6 @@ def debug_start_state_invalid(
     start_state: JointState,
 ):
     # TYLER DEBUG
-    breakpoint()
     graph_planner = motion_gen_config.graph_planner
     x_init_batch = start_state.position
     x_goal_batch = x_init_batch  # HACK
@@ -350,7 +349,7 @@ def new_solve_trajopt_batch(
 
     start_state = JointState.from_position(q_starts)
 
-    DEBUG_START_STATE_INVALID = False
+    DEBUG_START_STATE_INVALID = True
     if DEBUG_START_STATE_INVALID:
         debug_start_state_invalid(
             motion_gen_config=motion_gen_config, start_state=start_state
@@ -566,7 +565,7 @@ def solve_trajopt_batch(
 
     start_state = JointState.from_position(q_starts)
 
-    DEBUG_START_STATE_INVALID = False
+    DEBUG_START_STATE_INVALID = True
     if DEBUG_START_STATE_INVALID:
         debug_start_state_invalid(
             motion_gen_config=motion_gen_config, start_state=start_state

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -96,7 +96,7 @@ def debug_start_state_invalid(
         print("mask.all() == True, so no issues with start_state")
 
 
-def prepare_solve_trajopt_batch(
+def prepare_trajopt_batch(
     n_grasps: int,
     collision_check_object: bool = True,
     obj_filepath: Optional[pathlib.Path] = pathlib.Path(
@@ -353,7 +353,7 @@ def solve_trajopt_batch(
 ) -> Tuple[MotionGenResult, IKResult, IKResult]:
     N_GRASPS = X_W_Hs.shape[0]
     robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = (
-        prepare_solve_trajopt_batch(
+        prepare_trajopt_batch(
             n_grasps=N_GRASPS,
             collision_check_object=collision_check_object,
             obj_filepath=obj_filepath,

--- a/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/trajopt_batch.py
@@ -144,9 +144,10 @@ def debug_start_state_invalid(
         print(f"bound_constraint: {bound_constraint}")
         print(f"coll_constraint: {coll_constraint}")
         print(f"self_constraint: {self_constraint}")
+        print("PROBLEM WITH START_STATE")
         breakpoint()
     else:
-        print("mask.all() == True")
+        print("mask.all() == True, so no issues with start_state")
 
 
 def prepare_solve_trajopt_batch(
@@ -314,21 +315,6 @@ def new_solve_trajopt_batch(
             print("#" * 80)
             print("q_starts out of joint limits!")
             print("#" * 80)
-            print(
-                f"q_starts = {q_starts}, joint_lower_limits = {joint_lower_limits}, joint_upper_limits = {joint_upper_limits}"
-            )
-            print(
-                f"q_starts < joint_lower_limits = {(q_starts < joint_lower_limits[None]).any()}"
-            )
-            print(
-                f"q_starts > joint_upper_limits = {(q_starts > joint_upper_limits[None]).any()}"
-            )
-            print(
-                f"(q_starts < joint_lower_limits[None]).nonzero() = {(q_starts < joint_lower_limits[None]).nonzero()}"
-            )
-            print(
-                f"(q_starts > joint_upper_limits[None]).nonzero() = {(q_starts > joint_upper_limits[None]).nonzero()}"
-            )
 
             # HACK: Check if out of joint limits due to small numerical issues
             eps = 1e-4
@@ -345,6 +331,21 @@ def new_solve_trajopt_batch(
                 )
             else:
                 print("q_starts is far from joint limits, so not clamping")
+                print(
+                    f"q_starts = {q_starts}, joint_lower_limits = {joint_lower_limits}, joint_upper_limits = {joint_upper_limits}"
+                )
+                print(
+                    f"q_starts < joint_lower_limits = {(q_starts < joint_lower_limits[None]).any()}"
+                )
+                print(
+                    f"q_starts > joint_upper_limits = {(q_starts > joint_upper_limits[None]).any()}"
+                )
+                print(
+                    f"(q_starts < joint_lower_limits[None]).nonzero() = {(q_starts < joint_lower_limits[None]).nonzero()}"
+                )
+                print(
+                    f"(q_starts > joint_upper_limits[None]).nonzero() = {(q_starts > joint_upper_limits[None]).nonzero()}"
+                )
                 raise ValueError("q_starts out of joint limits!")
 
     start_state = JointState.from_position(q_starts)

--- a/nerf_grasping/curobo_fr3_algr_zed2i/visualizer.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/visualizer.py
@@ -43,12 +43,13 @@ def start_visualizer(object_urdf_path: Optional[pathlib.Path] = None):
     assert num_total_joints == 39
 
     if object_urdf_path is not None:
+        # TODO: Make htis not hardcoded
         assert object_urdf_path.exists()
         obj = pb.loadURDF(
             str(object_urdf_path),
             useFixedBase=True,
             basePosition=[
-                0.65,
+                10,
                 0,
                 0,
             ],

--- a/nerf_grasping/curobo_fr3_algr_zed2i/visualizer.py
+++ b/nerf_grasping/curobo_fr3_algr_zed2i/visualizer.py
@@ -1,7 +1,7 @@
 import pathlib
 from tqdm import tqdm
 import numpy as np
-from typing import Optional
+from typing import Optional, Tuple
 import pybullet as pb
 from curobo.util_file import (
     get_assets_path,
@@ -23,7 +23,11 @@ from nerf_grasping.curobo_fr3_algr_zed2i.trajopt_fr3_algr_zed2i import (
 )
 
 
-def start_visualizer(object_urdf_path: Optional[pathlib.Path] = None):
+def start_visualizer(
+    object_urdf_path: Optional[pathlib.Path] = None,
+    obj_xyz: Tuple[float, float, float] = (0.65, 0.0, 0.0),
+    obj_quat_wxyz: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+):
     FR3_ALGR_ZED2I_URDF_PATH = load_yaml(
         join_path(get_robot_configs_path(), "fr3_algr_zed2i_with_fingertips.yml")
     )["robot_cfg"]["kinematics"]["urdf_path"]
@@ -43,17 +47,13 @@ def start_visualizer(object_urdf_path: Optional[pathlib.Path] = None):
     assert num_total_joints == 39
 
     if object_urdf_path is not None:
-        # TODO: Make htis not hardcoded
         assert object_urdf_path.exists()
+        obj_quat_xyzw = obj_quat_wxyz[1:] + obj_quat_wxyz[:1]
         obj = pb.loadURDF(
             str(object_urdf_path),
             useFixedBase=True,
-            basePosition=[
-                10,
-                0,
-                0,
-            ],
-            baseOrientation=[0, 0, 0, 1],
+            basePosition=obj_xyz,
+            baseOrientation=obj_quat_xyzw,  # Must be xyzw
         )
 
     actuatable_joint_idxs = [

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -728,13 +728,14 @@ def run_curobo(
     objects_world_cfg = get_world_cfg(
         collision_check_object=True,
         obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-        obj_xyz=(cfg.nerf_frame_offset_x + 0.05, 0.0, 0.0),
+        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
     )
     ik_solver.update_world(objects_world_cfg)
     ik_solver2.update_world(objects_world_cfg)
     motion_gen.update_world(objects_world_cfg)
+    ik_solver.world_coll_checker.world_model.save_world_as_mesh("/tmp/CORRECT_world_mesh.obj")
     motion_gen_result, ik_result, ik_result2 = new_solve_trajopt_batch(
         X_W_Hs=X_W_Hs,
         q_algrs=q_algr_pres,
@@ -1102,14 +1103,16 @@ def run_pipeline(
 
     start_prepare_solve_trajopt_batch = time.time()
     # HACK: Need to include a mesh into the world for the motion_gen warmup or else it will not prepare mesh buffers
-    dummy_mesh = trimesh.creation.icosphere(radius=0.01)
+    # dummy_mesh = trimesh.creation.icosphere(radius=0.01)
+    dummy_mesh = trimesh.creation.box(extents=(0.01, 0.01, 0.01))
     dummy_mesh.export(file_obj="/tmp/DUMMY_mesh_viz_object.obj")
 
     # TODO: Check if warmup ik_solver
     robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = prepare_solve_trajopt_batch(
         n_grasps=X_W_Hs.shape[0],
         collision_check_object=True,
-        obj_filepath=pathlib.Path("/tmp/DUMMY_mesh_viz_object.obj"),
+        # obj_filepath=pathlib.Path("/tmp/DUMMY_mesh_viz_object.obj"),
+        obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
         obj_xyz=(10, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
@@ -1173,7 +1176,8 @@ def visualize(
         max_penetration_from_q,
     )
 
-    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/tmp/mesh_viz_object.obj"))
+    # OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/tmp/mesh_viz_object.obj"))
+    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"))
     pb_robot = start_visualizer(object_urdf_path=OBJECT_URDF_PATH)
     draw_collision_spheres_default_config(pb_robot)
     time.sleep(1.0)

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -724,6 +724,17 @@ def run_curobo(
     #     timeout=5.0,
     #     collision_sphere_buffer=0.01,
     # )
+
+    objects_world_cfg = get_world_cfg(
+        collision_check_object=True,
+        obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+        obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        collision_check_table=True,
+    )
+    ik_solver.update_world(objects_world_cfg)
+    ik_solver2.update_world(objects_world_cfg)
+    motion_gen.update_world(objects_world_cfg)
     motion_gen_result, ik_result, ik_result2 = new_solve_trajopt_batch(
         X_W_Hs=X_W_Hs,
         q_algrs=q_algr_pres,
@@ -1090,11 +1101,13 @@ def run_pipeline(
     print("@" * 80 + "\n")
 
     start_prepare_solve_trajopt_batch = time.time()
+    # TODO: Check if warmup ik_solver
     robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = prepare_solve_trajopt_batch(
         n_grasps=X_W_Hs.shape[0],
         collision_check_object=True,
-        obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+        # obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+        obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+        obj_xyz=(10, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
         use_cuda_graph=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -538,8 +538,11 @@ def run_curobo(
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
     )
+    ik_solver.world_coll_checker.clear_cache()
     ik_solver.update_world(object_world_cfg)
+    ik_solver2.world_coll_checker.clear_cache()
     ik_solver2.update_world(object_world_cfg)
+    motion_gen.world_coll_checker.clear_cache()
     motion_gen.update_world(object_world_cfg)
     motion_gen_result, ik_result, ik_result2 = (
         # solve_trajopt_batch(

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -529,6 +529,18 @@ def run_curobo(
     print("\n" + "=" * 80)
     print("Step 9: Solve motion gen for each grasp")
     print("=" * 80 + "\n")
+    object_world_cfg = get_world_cfg(
+        collision_check_object=True,
+        obj_filepath=pathlib.Path(
+            "/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"
+        ),
+        obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
+        obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        collision_check_table=True,
+    )
+    ik_solver.update_world(object_world_cfg)
+    ik_solver2.update_world(object_world_cfg)
+    motion_gen.update_world(object_world_cfg)
     motion_gen_result, ik_result, ik_result2 = (
         # solve_trajopt_batch(
         #     X_W_Hs=X_W_Hs,
@@ -1150,7 +1162,8 @@ def main() -> None:
         prepare_solve_trajopt_batch(
             n_grasps=args.num_grasps,
             collision_check_object=True,
-            obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
+            # obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
+            obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
             obj_xyz=(args.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
             obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
             collision_check_table=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -851,18 +851,17 @@ def run_curobo(
         q_start_lifts[i] = q_start_lifts[valid_idx]
         X_W_H_lifts[i] = X_W_H_lifts[valid_idx]
 
-    # Using existing motion_gen means that object collisions are still checked for lift
-    # May want to create new world
-    # no_objects_world_cfg = get_world_cfg(
-    #     collision_check_object=False,
-    #     obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-    #     obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
-    #     obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
-    #     collision_check_table=True,
-    # )
-    # ik_solver.update_world(no_objects_world_cfg)
-    # ik_solver2.update_world(no_objects_world_cfg)
-    # motion_gen.update_world(no_objects_world_cfg)
+    # Update world to remove object collision check
+    no_objects_world_cfg = get_world_cfg(
+        collision_check_object=False,
+        obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+        obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        collision_check_table=True,
+    )
+    ik_solver.update_world(no_objects_world_cfg)
+    ik_solver2.update_world(no_objects_world_cfg)
+    motion_gen.update_world(no_objects_world_cfg)
     lift_motion_gen_result, lift_ik_result, lift_ik_result2 = new_solve_trajopt_batch(
         X_W_Hs=X_W_H_lifts,
         q_algrs=q_algr_pres,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -487,24 +487,6 @@ def run_curobo(
     motion_gen_config: Optional[MotionGenConfig] = None,
     losses: Optional[np.ndarray] = None,
 ) -> Tuple[List[np.ndarray], List[np.ndarray], List[float], List[int], tuple]:
-    if (
-        robot_cfg is None
-        or ik_solver is None
-        or ik_solver2 is None
-        or motion_gen is None
-        or motion_gen_config is None
-    ):
-        print("\n" + "=" * 80)
-        print(f"robot_cfg is None: {robot_cfg is None}")
-        print(f"ik_solver is None: {ik_solver is None}")
-        print(f"ik_solver2 is None: {ik_solver2 is None}")
-        print(f"motion_gen is None: {motion_gen is None}")
-        print(f"motion_gen_config is None: {motion_gen_config is None}")
-        print("=" * 80 + "\n")
-        print(
-            "Creating new robot, ik_solver, ik_solver2, motion_gen, motion_gen_config"
-        )
-
     # Timing
     APPROACH_TIME = cfg.approach_time
     STAY_OPEN_TIME = cfg.stay_open_time
@@ -523,6 +505,36 @@ def run_curobo(
         q_algr = DEFAULT_Q_ALGR
     assert q_fr3.shape == (7,)
     assert q_algr.shape == (16,)
+
+    if (
+        robot_cfg is None
+        or ik_solver is None
+        or ik_solver2 is None
+        or motion_gen is None
+        or motion_gen_config is None
+    ):
+        print("\n" + "=" * 80)
+        print(f"robot_cfg is None: {robot_cfg is None}")
+        print(f"ik_solver is None: {ik_solver is None}")
+        print(f"ik_solver2 is None: {ik_solver2 is None}")
+        print(f"motion_gen is None: {motion_gen is None}")
+        print(f"motion_gen_config is None: {motion_gen_config is None}")
+        print("=" * 80 + "\n")
+        print(
+            "Creating new robot, ik_solver, ik_solver2, motion_gen, motion_gen_config"
+        )
+        robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = (
+            prepare_trajopt_batch(
+                n_grasps=n_grasps,
+                collision_check_object=True,
+                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+                obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+                obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+                collision_check_table=True,
+                use_cuda_graph=True,
+                collision_sphere_buffer=0.01,
+            )
+        )
 
     print("\n" + "=" * 80)
     print("Step 9: Solve motion gen for each grasp")

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -728,7 +728,7 @@ def run_curobo(
     objects_world_cfg = get_world_cfg(
         collision_check_object=True,
         obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+        obj_xyz=(cfg.nerf_frame_offset_x + 0.05, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
     )
@@ -1101,12 +1101,15 @@ def run_pipeline(
     print("@" * 80 + "\n")
 
     start_prepare_solve_trajopt_batch = time.time()
+    # HACK: Need to include a mesh into the world for the motion_gen warmup or else it will not prepare mesh buffers
+    dummy_mesh = trimesh.creation.icosphere(radius=0.01)
+    dummy_mesh.export(file_obj="/tmp/DUMMY_mesh_viz_object.obj")
+
     # TODO: Check if warmup ik_solver
     robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = prepare_solve_trajopt_batch(
         n_grasps=X_W_Hs.shape[0],
         collision_check_object=True,
-        # obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-        obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+        obj_filepath=pathlib.Path("/tmp/DUMMY_mesh_viz_object.obj"),
         obj_xyz=(10, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -540,14 +540,9 @@ def run_curobo(
         collision_check_table=True,
         obj_name="mesh_object",
     )
-    # ik_solver.world_coll_checker.clear_cache()
     ik_solver.update_world(object_world_cfg)
-    # ik_solver2.world_coll_checker.clear_cache()
     ik_solver2.update_world(object_world_cfg)
-    # motion_gen.world_coll_checker.clear_cache()
-    breakpoint()
     motion_gen.update_world(object_world_cfg)
-    breakpoint()
     motion_gen_result, ik_result, ik_result2 = (
         # solve_trajopt_batch(
         #     X_W_Hs=X_W_Hs,
@@ -693,6 +688,20 @@ def run_curobo(
         X_W_H_lifts[i] = X_W_H_lifts[valid_idx]
 
     # Update world to remove object collision check
+    no_object_world_cfg = get_world_cfg(
+        collision_check_object=True,
+        obj_filepath=pathlib.Path(
+            # "/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"
+            "/tmp/mesh_viz_object.obj"
+        ),
+        obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 1.0),
+        obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+        collision_check_table=True,
+        obj_name="no_object",
+    )
+    ik_solver.update_world(no_object_world_cfg)
+    ik_solver2.update_world(no_object_world_cfg)
+
     lift_motion_gen_result, lift_ik_result, lift_ik_result2 = (
         # solve_trajopt_batch(
         #     X_W_Hs=X_W_H_lifts,
@@ -1170,7 +1179,6 @@ def main() -> None:
             n_grasps=args.num_grasps,
             collision_check_object=True,
             obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
-            # obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
             obj_xyz=(args.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
             obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
             collision_check_table=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -57,7 +57,7 @@ print = partial(
     print, file=sys.stderr
 )  # Redirect print to stderr to get around ROS issue
 
-HACK_OFFSET = -0.05
+HACK_OFFSET = 2
 
 @dataclass
 class PipelineConfig:
@@ -533,7 +533,7 @@ def run_curobo(
         q_fr3_starts=q_fr3[None, ...].repeat(n_grasps, axis=0),
         q_algr_starts=q_algr[None, ...].repeat(n_grasps, axis=0),
         collision_check_object=True,
-        obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+        obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
         obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
@@ -665,7 +665,7 @@ def run_curobo(
                 :, 7:
             ],  # We don't want to care about hand joints, just arm joints, so this doesn't matter much as long as not in collision with table
             collision_check_object=False,
-            obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+            obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
             obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
             obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
             collision_check_table=True,
@@ -925,7 +925,7 @@ def visualize(
         max_penetration_from_q,
     )
 
-    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/tmp/mesh_viz_object.obj"))
+    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"))
     pb_robot = start_visualizer(
         object_urdf_path=OBJECT_URDF_PATH,
         obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
@@ -986,7 +986,7 @@ def visualize(
                 qs=q,
                 collision_activation_distance=0.0,
                 include_object=True,
-                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+                obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
                 obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,
@@ -1004,7 +1004,7 @@ def visualize(
             d_world, d_self = max_penetration_from_q(
                 q=ik_q,
                 include_object=True,
-                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+                obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
                 obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -667,7 +667,7 @@ def run_curobo(
 
     # Update world to remove object collision check
     no_object_world_cfg = get_world_cfg(
-        collision_check_object=True,
+        collision_check_object=False,
         obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
         obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 1.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
@@ -1137,13 +1137,14 @@ def main() -> None:
     start_prepare_solve_trajopt_batch = time.time()
     # HACK: Need to include a mesh into the world for the motion_gen warmup or else it will not prepare mesh buffers
     mesh = trimesh.creation.box(extents=(0.1, 0.1, 0.1))
-    mesh.export("/tmp/DUMMY_mesh_viz_object.obj")
+    mesh.export("/tmp/DUMMY.obj")
+    FAR_AWAY_OBJ_XYZ = (10.0, 0.0, 0.0)
     robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = (
         prepare_solve_trajopt_batch(
             n_grasps=args.num_grasps,
             collision_check_object=True,
-            obj_filepath=pathlib.Path("/tmp/DUMMY_mesh_viz_object.obj"),
-            obj_xyz=(args.nerf_frame_offset_x, 0.0, 0.0),
+            obj_filepath=pathlib.Path("/tmp/DUMMY.obj"),
+            obj_xyz=FAR_AWAY_OBJ_XYZ,
             obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
             collision_check_table=True,
             use_cuda_graph=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -532,12 +532,13 @@ def run_curobo(
     object_world_cfg = get_world_cfg(
         collision_check_object=True,
         obj_filepath=pathlib.Path(
-            "/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"
-            # "/tmp/mesh_viz_object.obj"
+            # "/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"
+            "/tmp/mesh_viz_object.obj"
         ),
         obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
+        obj_name="mesh_object",
     )
     # ik_solver.world_coll_checker.clear_cache()
     ik_solver.update_world(object_world_cfg)
@@ -1168,8 +1169,8 @@ def main() -> None:
         prepare_solve_trajopt_batch(
             n_grasps=args.num_grasps,
             collision_check_object=True,
-            # obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
-            obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
+            obj_filepath=pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"),
+            # obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
             obj_xyz=(args.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
             obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
             collision_check_table=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -533,7 +533,7 @@ def run_curobo(
         obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
-        obj_name="mesh_object",
+        obj_name="NERF_OBJECT",  # HACK: MUST BE DIFFERENT FROM EXISTING OBJECT NAME "object" OR ELSE COLLISION DETECTION WILL FAIL
     )
     ik_solver.update_world(object_world_cfg)
     ik_solver2.update_world(object_world_cfg)
@@ -672,7 +672,7 @@ def run_curobo(
         obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
-        obj_name="no_object",
+        obj_name="NO_OBJECT",  # HACK: MUST BE DIFFERENT FROM EXISTING OBJECT NAME "object" OR ELSE COLLISION DETECTION WILL FAIL
     )
     ik_solver.update_world(no_object_world_cfg)
     ik_solver2.update_world(no_object_world_cfg)
@@ -1004,9 +1004,7 @@ def visualize(
                 qs=q,
                 collision_activation_distance=0.0,
                 include_object=True,
-                obj_filepath=pathlib.Path(
-                    "/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"
-                ),
+                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
                 obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,
@@ -1024,9 +1022,7 @@ def visualize(
             d_world, d_self = max_penetration_from_q(
                 q=ik_q,
                 include_object=True,
-                obj_filepath=pathlib.Path(
-                    "/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"
-                ),
+                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
                 obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -533,7 +533,7 @@ def run_curobo(
         q_fr3_starts=q_fr3[None, ...].repeat(n_grasps, axis=0),
         q_algr_starts=q_algr[None, ...].repeat(n_grasps, axis=0),
         collision_check_object=True,
-        obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+        obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
         obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
@@ -665,7 +665,7 @@ def run_curobo(
                 :, 7:
             ],  # We don't want to care about hand joints, just arm joints, so this doesn't matter much as long as not in collision with table
             collision_check_object=False,
-            obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+            obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
             obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
             obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
             collision_check_table=True,
@@ -925,7 +925,7 @@ def visualize(
         max_penetration_from_q,
     )
 
-    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"))
+    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/tmp/mesh_viz_object.obj"))
     pb_robot = start_visualizer(
         object_urdf_path=OBJECT_URDF_PATH,
         obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
@@ -986,7 +986,7 @@ def visualize(
                 qs=q,
                 collision_activation_distance=0.0,
                 include_object=True,
-                obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
                 obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,
@@ -1004,7 +1004,7 @@ def visualize(
             d_world, d_self = max_penetration_from_q(
                 q=ik_q,
                 include_object=True,
-                obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
                 obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,
@@ -1118,7 +1118,7 @@ def main() -> None:
     #     prepare_solve_trajopt_batch(
     #         n_grasps=args.num_grasps,
     #         collision_check_object=True,
-    #         obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+    #         obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
     #         obj_xyz=(args.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
     #         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
     #         collision_check_table=True,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -43,6 +43,10 @@ from nerf_grasping.curobo_fr3_algr_zed2i.trajopt_fr3_algr_zed2i import (
     DEFAULT_Q_FR3,
     DEFAULT_Q_ALGR,
 )
+from functools import partial
+
+import sys
+print = partial(print, file=sys.stderr)
 
 from curobo.types.robot import RobotConfig, JointState
 from curobo.wrap.reacher.ik_solver import IKSolver, IKSolverConfig, IKResult
@@ -1056,6 +1060,7 @@ def run_pipeline(
 
     start_prepare_solve_trajopt_batch = time.time()
     robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = prepare_solve_trajopt_batch(
+        n_grasps=X_W_Hs.shape[0],
         collision_check_object=True,
         obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
         obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
@@ -1069,6 +1074,7 @@ def run_pipeline(
     print(f"Time to prepare_solve_trajopt_batch: {end_prepare_solve_trajopt_batch - start_prepare_solve_trajopt_batch:.2f}s")
     print("@" * 80 + "\n")
 
+    start_run_curobo = time.time()
     qs, qds, T_trajs, success_idxs, DEBUG_TUPLE = run_curobo(
         cfg=cfg,
         X_W_Hs=X_W_Hs,
@@ -1085,7 +1091,7 @@ def run_pipeline(
     )
     curobo_time = time.time()
     print("@" * 80)
-    print(f"Time to run_curobo: {curobo_time - compute_grasps_time:.2f}s")
+    print(f"Time to run_curobo: {curobo_time - start_run_curobo:.2f}s")
     print("@" * 80 + "\n")
 
     print("\n" + "=" * 80)

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -31,7 +31,7 @@ import plotly.graph_objects as go
 from datetime import datetime
 
 from nerf_grasping.curobo_fr3_algr_zed2i.trajopt_batch import (
-    prepare_solve_trajopt_batch,
+    prepare_trajopt_batch,
     solve_prepared_trajopt_batch,
     get_trajectories_from_result,
     compute_over_limit_factors,
@@ -1130,13 +1130,13 @@ def main() -> None:
     args.nerf_config = nerf_config
 
     # Prepare curobo
-    start_prepare_solve_trajopt_batch = time.time()
+    start_prepare_trajopt_batch = time.time()
     # HACK: Need to include a mesh into the world for the motion_gen warmup or else it will not prepare mesh buffers
     mesh = trimesh.creation.box(extents=(0.1, 0.1, 0.1))
     mesh.export("/tmp/DUMMY.obj")
     FAR_AWAY_OBJ_XYZ = (10.0, 0.0, 0.0)
     robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = (
-        prepare_solve_trajopt_batch(
+        prepare_trajopt_batch(
             n_grasps=args.num_grasps,
             collision_check_object=True,
             obj_filepath=pathlib.Path("/tmp/DUMMY.obj"),
@@ -1147,10 +1147,10 @@ def main() -> None:
             collision_sphere_buffer=0.01,
         )
     )
-    end_prepare_solve_trajopt_batch = time.time()
+    end_prepare_trajopt_batch = time.time()
     print("@" * 80)
     print(
-        f"Time to prepare_solve_trajopt_batch: {end_prepare_solve_trajopt_batch - start_prepare_solve_trajopt_batch:.2f}s"
+        f"Time to prepare_trajopt_batch: {end_prepare_trajopt_batch - start_prepare_trajopt_batch:.2f}s"
     )
     print("@" * 80 + "\n")
 

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -59,7 +59,7 @@ print = partial(
     print, file=sys.stderr
 )  # Redirect print to stderr to get around ROS issue
 
-HACK_OFFSET = 0.1
+HACK_OFFSET = 0.0
 
 @dataclass
 class PipelineConfig:
@@ -533,17 +533,20 @@ def run_curobo(
         collision_check_object=True,
         obj_filepath=pathlib.Path(
             "/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata/core-bottle-1071fa4cddb2da2fc8724d5673a063a6/coacd/decomposed.obj"
+            # "/tmp/mesh_viz_object.obj"
         ),
         obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
     )
-    ik_solver.world_coll_checker.clear_cache()
+    # ik_solver.world_coll_checker.clear_cache()
     ik_solver.update_world(object_world_cfg)
-    ik_solver2.world_coll_checker.clear_cache()
+    # ik_solver2.world_coll_checker.clear_cache()
     ik_solver2.update_world(object_world_cfg)
-    motion_gen.world_coll_checker.clear_cache()
+    # motion_gen.world_coll_checker.clear_cache()
+    breakpoint()
     motion_gen.update_world(object_world_cfg)
+    breakpoint()
     motion_gen_result, ik_result, ik_result2 = (
         # solve_trajopt_batch(
         #     X_W_Hs=X_W_Hs,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -59,6 +59,7 @@ print = partial(
     print, file=sys.stderr
 )  # Redirect print to stderr to get around ROS issue
 
+HACK_OFFSET = -0.05
 
 @dataclass
 class PipelineConfig:
@@ -509,8 +510,8 @@ def run_curobo(
             prepare_solve_trajopt_batch(
                 n_grasps=cfg.num_grasps,
                 collision_check_object=True,
-                obj_filepath=pathlib.Path("/tmp/DUMMY_mesh_viz_object.obj"),
-                obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+                obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+                obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 collision_check_table=True,
                 use_cuda_graph=True,
@@ -541,8 +542,8 @@ def run_curobo(
     print("=" * 80 + "\n")
     objects_world_cfg = get_world_cfg(
         collision_check_object=True,
-        obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+        obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+        obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
     )
@@ -679,8 +680,8 @@ def run_curobo(
     # Update world to remove object collision check
     no_objects_world_cfg = get_world_cfg(
         collision_check_object=False,
-        obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+        obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+        obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
     )
@@ -955,10 +956,10 @@ def visualize(
         max_penetration_from_q,
     )
 
-    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/tmp/mesh_viz_object.obj"))
+    OBJECT_URDF_PATH = create_urdf(obj_path=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"))
     pb_robot = start_visualizer(
         object_urdf_path=OBJECT_URDF_PATH,
-        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+        obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
     )
     draw_collision_spheres_default_config(pb_robot)
@@ -1016,8 +1017,8 @@ def visualize(
                 qs=q,
                 collision_activation_distance=0.0,
                 include_object=True,
-                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-                obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+                obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+                obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,
             )
@@ -1034,8 +1035,8 @@ def visualize(
             d_world, d_self = max_penetration_from_q(
                 q=ik_q,
                 include_object=True,
-                obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-                obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+                obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+                obj_xyz=(cfg.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
                 obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
                 include_table=True,
             )
@@ -1144,23 +1145,18 @@ def main() -> None:
     # Prepare curobo
     start_prepare_solve_trajopt_batch = time.time()
     # HACK: Need to include a mesh into the world for the motion_gen warmup or else it will not prepare mesh buffers
-    # dummy_mesh = trimesh.creation.icosphere(radius=0.01)
-    dummy_mesh = trimesh.creation.box(extents=(0.01, 0.01, 0.01))
-    dummy_mesh.export(file_obj="/tmp/DUMMY_mesh_viz_object.obj")
-
-    robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = (
-        prepare_solve_trajopt_batch(
-            n_grasps=args.num_grasps,
-            collision_check_object=True,
-            obj_filepath=pathlib.Path("/tmp/DUMMY_mesh_viz_object.obj"),
-            # obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
-            obj_xyz=(10, 0.0, 0.0),
-            obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
-            collision_check_table=True,
-            use_cuda_graph=True,
-            collision_sphere_buffer=0.01,
-        )
-    )
+    # robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = (
+    #     prepare_solve_trajopt_batch(
+    #         n_grasps=args.num_grasps,
+    #         collision_check_object=True,
+    #         obj_filepath=pathlib.Path("/juno/u/tylerlum/Downloads/cube.obj"),
+    #         obj_xyz=(args.nerf_frame_offset_x + HACK_OFFSET, 0.0, 0.0),
+    #         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+    #         collision_check_table=True,
+    #         use_cuda_graph=True,
+    #         collision_sphere_buffer=0.01,
+    #     )
+    # )
     end_prepare_solve_trajopt_batch = time.time()
     print("@" * 80)
     print(
@@ -1173,11 +1169,11 @@ def main() -> None:
         cfg=args,
         q_fr3=DEFAULT_Q_FR3,
         q_algr=DEFAULT_Q_ALGR,
-        robot_cfg=robot_cfg,
-        ik_solver=ik_solver,
-        ik_solver2=ik_solver2,
-        motion_gen=motion_gen,
-        motion_gen_config=motion_gen_config,
+        # robot_cfg=robot_cfg,
+        # ik_solver=ik_solver,
+        # ik_solver2=ik_solver2,
+        # motion_gen=motion_gen,
+        # motion_gen_config=motion_gen_config,
     )
 
     visualize(

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -669,14 +669,14 @@ def run_curobo(
     no_object_world_cfg = get_world_cfg(
         collision_check_object=False,
         obj_filepath=pathlib.Path("/tmp/mesh_viz_object.obj"),
-        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 1.0),
+        obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
         obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
         collision_check_table=True,
         obj_name="no_object",
     )
     ik_solver.update_world(no_object_world_cfg)
     ik_solver2.update_world(no_object_world_cfg)
-
+    motion_gen.update_world(object_world_cfg)
     lift_motion_gen_result, lift_ik_result, lift_ik_result2 = (
         solve_prepared_trajopt_batch(
             X_W_Hs=X_W_H_lifts,

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -57,7 +57,7 @@ print = partial(
     print, file=sys.stderr
 )  # Redirect print to stderr to get around ROS issue
 
-HACK_OFFSET = 2
+HACK_OFFSET = 0.1
 
 @dataclass
 class PipelineConfig:

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -497,12 +497,6 @@ def run_curobo(
     n_grasps = X_W_Hs.shape[0]
     assert X_W_Hs.shape == (n_grasps, 4, 4)
     assert q_algr_pres.shape == (n_grasps, 16)
-    if q_fr3 is None:
-        print("Using default q_fr3")
-        q_fr3 = DEFAULT_Q_FR3
-    if q_algr is None:
-        print("Using default q_algr")
-        q_algr = DEFAULT_Q_ALGR
     assert q_fr3.shape == (7,)
     assert q_algr.shape == (16,)
 

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -1,4 +1,3 @@
-from tqdm import tqdm
 import time
 from typing import Optional, Tuple, List
 from nerfstudio.models.base_model import Model
@@ -475,199 +474,49 @@ def compute_grasps(
     )
 
 
-def run_drake(
-    cfg: PipelineConfig,
-    X_W_Hs: np.ndarray,
-    q_algr_pres: np.ndarray,
-    q_algr_posts: np.ndarray,
-) -> None:
-    from nerf_grasping.fr3_algr_ik.ik import solve_ik
-
-    num_grasps = X_W_Hs.shape[0]
-    q_stars = []
-    for i in tqdm(range(num_grasps)):
-        X_W_H = X_W_Hs[i]
-        q_algr_pre = q_algr_pres[i]
-
-        try:
-            q_star = solve_ik(X_W_H=X_W_H, q_algr_pre=q_algr_pre, visualize=False)
-            print(f"Success for grasp {i}")
-            q_stars.append(q_star)
-        except RuntimeError as e:
-            print(f"Failed to solve IK for grasp {i}")
-            q_stars.append(None)
-    assert len(q_stars) == num_grasps
-    num_passed = sum([q_star is not None for q_star in q_stars])
-    print(
-        f"Number of grasps passed IK: {num_passed} / {num_grasps} ({num_passed / num_grasps * 100:.2f}%)"
-    )
-
-    print("\n" + "=" * 80)
-    print("Step 9: Solve trajopt for each grasp")
-    print("=" * 80 + "\n")
-
-    from nerf_grasping.fr3_algr_trajopt.trajopt import (
-        solve_trajopt,
-        TrajOptParams,
-        DEFAULT_Q_FR3,
-        DEFAULT_Q_ALGR,
-    )
-
-    trajopt_cfg = TrajOptParams(
-        num_control_points=21,
-        min_self_coll_dist=0.005,
-        influence_dist=0.01,
-        nerf_frame_offset=cfg.nerf_frame_offset_x,
-        s_start_self_col=0.5,
-        lqr_pos_weight=1e-1,
-        lqr_vel_weight=20.0,
-        presolve_no_collision=True,
-    )
-    USE_DEFAULT_Q_0 = True
-    if USE_DEFAULT_Q_0:
-        print("Using default q_0")
-        q_fr3_0 = DEFAULT_Q_FR3
-        q_algr_0 = DEFAULT_Q_ALGR
-    else:
-        raise NotImplementedError
-
-    passing_trajopt_idxs = []
-    failed_trajopt_idxs = []
-    not_attempted_trajopt_idxs = []
-    for i, q_star in tqdm(enumerate(q_stars), total=num_grasps):
-        if q_star is None:
-            not_attempted_trajopt_idxs.append(i)
-            continue
-
-        try:
-            spline, dspline, T_traj, trajopt = solve_trajopt(
-                q_fr3_0=q_fr3_0,
-                q_algr_0=q_algr_0,
-                q_fr3_f=q_star[:7],
-                q_algr_f=q_star[7:],
-                cfg=trajopt_cfg,
-                mesh_path=pathlib.Path("/tmp/mesh_viz_object.obj"),
-                visualize=False,
-                verbose=False,
-                ignore_obj_collision=False,
-            )
-            passing_trajopt_idxs.append(i)
-
-        except RuntimeError as e:
-            failed_trajopt_idxs.append(i)
-
-    print(f"passing_trajopt_idxs: {passing_trajopt_idxs}")
-    print(f"failed_trajopt_idxs: {failed_trajopt_idxs}")
-    print(f"not_attempted_trajopt_idxs: {not_attempted_trajopt_idxs}")
-
-    TRAJ_IDX = passing_trajopt_idxs[0] if len(passing_trajopt_idxs) > 0 else 0
-    print(f"Visualizing trajectory {TRAJ_IDX}")
-    try:
-        spline, dspline, T_traj, trajopt = solve_trajopt(
-            q_fr3_0=q_fr3_0,
-            q_algr_0=q_algr_0,
-            q_fr3_f=q_stars[TRAJ_IDX][:7],
-            q_algr_f=q_stars[TRAJ_IDX][7:],
-            cfg=trajopt_cfg,
-            mesh_path=pathlib.Path("/tmp/mesh_viz_object.obj"),
-            visualize=True,
-            verbose=False,
-            ignore_obj_collision=False,
-        )
-    except RuntimeError as e:
-        print(f"Failed to visualize trajectory {TRAJ_IDX}")
-
-    while True:
-        input_options = "\n".join(
-            [
-                "=====================",
-                "OPTIONS",
-                "b for breakpoint",
-                "r to run trajopt with object collision",
-                "o to run trajopt without object collision",
-                "n to go to next traj",
-                "p to go to prev traj",
-                "q to quit",
-                "=====================",
-            ]
-        )
-
-        x = input("\n" + input_options + "\n\n")
-        if x == "b":
-            print("Breakpoint")
-            breakpoint()
-        elif x == "r":
-            print(f"Visualizing trajectory {TRAJ_IDX} with object collision")
-            if q_stars[TRAJ_IDX] is not None:
-                try:
-                    spline, dspline, T_traj, trajopt = solve_trajopt(
-                        q_fr3_0=q_fr3_0,
-                        q_algr_0=q_algr_0,
-                        q_fr3_f=q_stars[TRAJ_IDX][:7],
-                        q_algr_f=q_stars[TRAJ_IDX][7:],
-                        cfg=trajopt_cfg,
-                        mesh_path=pathlib.Path("/tmp/mesh_viz_object.obj"),
-                        visualize=True,
-                        verbose=False,
-                        ignore_obj_collision=False,
-                    )
-                except RuntimeError as e:
-                    print(f"Failed to visualize trajectory {TRAJ_IDX}")
-            else:
-                print(f"Trajectory {TRAJ_IDX} is None, skipping")
-        elif x == "o":
-            print(f"Visualizing trajectory {TRAJ_IDX} without object collision")
-            if q_stars[TRAJ_IDX] is not None:
-                try:
-                    spline, dspline, T_traj, trajopt = solve_trajopt(
-                        q_fr3_0=q_fr3_0,
-                        q_algr_0=q_algr_0,
-                        q_fr3_f=q_stars[TRAJ_IDX][:7],
-                        q_algr_f=q_stars[TRAJ_IDX][7:],
-                        cfg=trajopt_cfg,
-                        mesh_path=pathlib.Path("/tmp/mesh_viz_object.obj"),
-                        visualize=True,
-                        verbose=False,
-                        ignore_obj_collision=True,
-                    )
-                except RuntimeError as e:
-                    print(f"Failed to visualize trajectory {TRAJ_IDX}")
-            else:
-                print(f"Trajectory {TRAJ_IDX} is None, skipping")
-        elif x == "n":
-            TRAJ_IDX += 1
-            if TRAJ_IDX >= num_grasps:
-                TRAJ_IDX = 0
-            print(f"Using trajectory {TRAJ_IDX}")
-        elif x == "p":
-            TRAJ_IDX -= 1
-            if TRAJ_IDX < 0:
-                TRAJ_IDX = num_grasps - 1
-            print(f"Using trajectory {TRAJ_IDX}")
-        elif x == "q":
-            print("Quitting")
-            break
-        else:
-            print(f"Invalid input: {x}")
-
-    print("Breakpoint to visualize")
-    breakpoint()
-
-
 def run_curobo(
     cfg: PipelineConfig,
     X_W_Hs: np.ndarray,
     q_algr_pres: np.ndarray,
     q_algr_posts: np.ndarray,
-    robot_cfg: RobotConfig,
-    ik_solver: IKSolver,
-    ik_solver2: IKSolver,
-    motion_gen: MotionGen,
-    motion_gen_config: MotionGenConfig,
+    q_fr3: np.ndarray,
+    q_algr: np.ndarray,
+    robot_cfg: Optional[RobotConfig] = None,
+    ik_solver: Optional[IKSolver] = None,
+    ik_solver2: Optional[IKSolver] = None,
+    motion_gen: Optional[MotionGen] = None,
+    motion_gen_config: Optional[MotionGenConfig] = None,
     losses: Optional[np.ndarray] = None,
-    q_fr3: Optional[np.ndarray] = None,
-    q_algr: Optional[np.ndarray] = None,
 ) -> Tuple[List[np.ndarray], List[np.ndarray], List[float], List[int], tuple]:
+    if (
+        robot_cfg is None
+        or ik_solver is None
+        or ik_solver2 is None
+        or motion_gen is None
+        or motion_gen_config is None
+    ):
+        print("\n" + "=" * 80)
+        print(f"robot_cfg is None: {robot_cfg is None}")
+        print(f"ik_solver is None: {ik_solver is None}")
+        print(f"ik_solver2 is None: {ik_solver2 is None}")
+        print(f"motion_gen is None: {motion_gen is None}")
+        print(f"motion_gen_config is None: {motion_gen_config is None}")
+        print("=" * 80 + "\n")
+        print(
+            "Creating new robot, ik_solver, ik_solver2, motion_gen, motion_gen_config"
+        )
+        robot_cfg, ik_solver, ik_solver2, motion_gen, motion_gen_config = (
+            prepare_solve_trajopt_batch(
+                n_grasps=cfg.num_grasps,
+                collision_check_object=True,
+                obj_filepath=pathlib.Path("/tmp/DUMMY_mesh_viz_object.obj"),
+                obj_xyz=(cfg.nerf_frame_offset_x, 0.0, 0.0),
+                obj_quat_wxyz=(1.0, 0.0, 0.0, 0.0),
+                collision_check_table=True,
+                use_cuda_graph=True,
+            )
+        )
+
     # Timing
     APPROACH_TIME = cfg.approach_time
     STAY_OPEN_TIME = cfg.stay_open_time
@@ -838,21 +687,23 @@ def run_curobo(
     ik_solver.update_world(no_objects_world_cfg)
     ik_solver2.update_world(no_objects_world_cfg)
     motion_gen.update_world(no_objects_world_cfg)
-    lift_motion_gen_result, lift_ik_result, lift_ik_result2 = solve_prepared_trajopt_batch(
-        X_W_Hs=X_W_H_lifts,
-        q_algrs=q_algr_pres,
-        q_fr3_starts=q_start_lifts[:, :7],
-        q_algr_starts=q_start_lifts[
-            :, 7:
-        ],  # We don't want to care about hand joints, just arm joints, so this doesn't matter much as long as not in collision with table
-        robot_cfg=robot_cfg,
-        ik_solver=ik_solver,
-        ik_solver2=ik_solver2,
-        motion_gen=motion_gen,
-        motion_gen_config=motion_gen_config,
-        enable_graph=True,
-        enable_opt=False,
-        timeout=3.0,
+    lift_motion_gen_result, lift_ik_result, lift_ik_result2 = (
+        solve_prepared_trajopt_batch(
+            X_W_Hs=X_W_H_lifts,
+            q_algrs=q_algr_pres,
+            q_fr3_starts=q_start_lifts[:, :7],
+            q_algr_starts=q_start_lifts[
+                :, 7:
+            ],  # We don't want to care about hand joints, just arm joints, so this doesn't matter much as long as not in collision with table
+            robot_cfg=robot_cfg,
+            ik_solver=ik_solver,
+            ik_solver2=ik_solver2,
+            motion_gen=motion_gen,
+            motion_gen_config=motion_gen_config,
+            enable_graph=True,
+            enable_opt=False,
+            timeout=3.0,
+        )
     )
 
     lift_motion_gen_success_idxs = (
@@ -1029,8 +880,13 @@ def run_curobo(
 def run_pipeline(
     nerf_model: Model,
     cfg: PipelineConfig,
-    q_fr3: Optional[np.ndarray] = None,
-    q_algr: Optional[np.ndarray] = None,
+    q_fr3: np.ndarray,
+    q_algr: np.ndarray,
+    robot_cfg: Optional[RobotConfig] = None,
+    ik_solver: Optional[IKSolver] = None,
+    ik_solver2: Optional[IKSolver] = None,
+    motion_gen: Optional[MotionGen] = None,
+    motion_gen_config: Optional[MotionGenConfig] = None,
 ) -> Tuple[List[np.ndarray], List[np.ndarray], List[float], List[int], tuple]:
 
     start_time = time.time()
@@ -1313,7 +1169,15 @@ def main() -> None:
     print("@" * 80 + "\n")
 
     qs, qds, T_trajs, success_idxs, DEBUG_TUPLE = run_pipeline(
-        nerf_model=nerf_model, cfg=args
+        nerf_model=nerf_model,
+        cfg=args,
+        q_fr3=DEFAULT_Q_FR3,
+        q_algr=DEFAULT_Q_ALGR,
+        robot_cfg=robot_cfg,
+        ik_solver=ik_solver,
+        ik_solver2=ik_solver2,
+        motion_gen=motion_gen,
+        motion_gen_config=motion_gen_config,
     )
 
     visualize(


### PR DESCRIPTION
Changes:
* Add `prepare_trajopt_batch` and `solve_prepared_trajopt_batch` to allow warmup for amortization
* Add ability to set the object name in the world config, which is VERY IMPORTANT to ensure that we can update world and properly modify the collision checking, we need to make sure they are different names when updating or else it may get confused
* Add safety buffer for joint vel limits
* Fix visualizer not hardcoded obj position
* Print to stderr
* Remove drake code
* Take in q_fr3 and q_algr 
* Make math_utils.py
* Add default min_len of 200 to avoid floaters in nerf_to_mesh
* Clean up