### PR TITLE
2024 05 27 new method

### DIFF
--- a/nerf_grasping/classifier.py
+++ b/nerf_grasping/classifier.py
@@ -5,6 +5,8 @@ import nerf_grasping
 import pathlib
 from nerf_grasping.models.dexgraspnet_models import (
     CNN_3D_Model,
+    CNN_3D_CNN_3D_Model,
+    CNN_3D_MLP_Model,
     CNN_2D_1D_Model,
     Simple_CNN_2D_1D_Model,
     Simple_CNN_1D_2D_Model,
@@ -118,7 +120,6 @@ class CNN_3D_XYZY_Classifier(Classifier):
         return all_logits
 
 
-
 class CNN_3D_XYZXYZY_Classifier(Classifier):
     def __init__(
         self,
@@ -193,6 +194,70 @@ class CNN_3D_XYZ_Classifier(Classifier):
         # Run model
         all_logits = self.model.get_all_logits(
             batch_data_input.nerf_alphas_with_augmented_coords
+        )
+        return all_logits
+
+
+class CNN_3D_XYZ_Global_CNN_Classifier(Classifier):
+    def __init__(
+        self,
+        input_shape: Iterable[int],
+        conv_channels: Iterable[int],
+        mlp_hidden_layers: Iterable[int],
+        global_input_shape: Iterable[int],
+        global_conv_channels: Iterable[int],
+        n_fingers: int,
+        n_tasks: int,
+    ) -> None:
+        super().__init__()
+        self.model = CNN_3D_CNN_3D_Model(
+            input_shape=input_shape,
+            conv_channels=conv_channels,
+            mlp_hidden_layers=mlp_hidden_layers,
+            global_input_shape=global_input_shape,
+            global_conv_channels=global_conv_channels,
+            n_fingers=n_fingers,
+            n_tasks=n_tasks,
+        )
+
+    def forward(self, batch_data_input: BatchDataInput) -> torch.Tensor:
+        # Run model
+        all_logits = self.model.get_all_logits(
+            batch_data_input.nerf_alphas_with_augmented_coords,
+            batch_data_input.global_nerf_alphas_with_augmented_coords,
+        )
+        return all_logits
+
+
+class CNN_3D_XYZ_Global_MLP_Classifier(Classifier):
+    def __init__(
+        self,
+        input_shape: Iterable[int],
+        conv_channels: Iterable[int],
+        mlp_hidden_layers: Iterable[int],
+        global_input_shape: Iterable[int],
+        global_mlp_hidden_layers: Iterable[int],
+        n_fingers: int,
+        n_tasks: int,
+    ) -> None:
+        super().__init__()
+        self.model = CNN_3D_MLP_Model(
+            input_shape=input_shape,
+            conv_channels=conv_channels,
+            mlp_hidden_layers=mlp_hidden_layers,
+            global_input_shape=global_input_shape,
+            global_mlp_hidden_layers=global_mlp_hidden_layers,
+            n_fingers=n_fingers,
+            n_tasks=n_tasks,
+        )
+
+    def forward(self, batch_data_input: BatchDataInput) -> torch.Tensor:
+        # Run model
+        all_logits = self.model.get_all_logits(
+            batch_data_input.nerf_alphas_with_augmented_coords,
+            batch_data_input.global_nerf_alphas.reshape(
+                batch_data_input.batch_size, -1
+            ),
         )
         return all_logits
 

--- a/nerf_grasping/classifier.py
+++ b/nerf_grasping/classifier.py
@@ -224,7 +224,7 @@ class CNN_3D_XYZ_Global_CNN_Classifier(Classifier):
         # Run model
         all_logits = self.model.get_all_logits(
             batch_data_input.nerf_alphas_with_augmented_coords,
-            batch_data_input.global_nerf_alphas_with_augmented_coords,
+            batch_data_input.nerf_alphas_global_with_augmented_coords,
         )
         return all_logits
 
@@ -255,7 +255,7 @@ class CNN_3D_XYZ_Global_MLP_Classifier(Classifier):
         # Run model
         all_logits = self.model.get_all_logits(
             batch_data_input.nerf_alphas_with_augmented_coords,
-            batch_data_input.global_nerf_alphas.reshape(
+            batch_data_input.nerf_alphas_global.reshape(
                 batch_data_input.batch_size, -1
             ),
         )

--- a/nerf_grasping/config/classifier_config.py
+++ b/nerf_grasping/config/classifier_config.py
@@ -279,7 +279,7 @@ class ClassifierModelConfig:
 
 @dataclass(frozen=True)
 class CNN_3D_XYZY_ModelConfig(ClassifierModelConfig):
-    """"Parameters for the CNN_3D_XYZY_Classifier."""
+    """Parameters for the CNN_3D_XYZY_Classifier."""
 
     conv_channels: List[int]
     """List of channels for each convolutional layer. Length specifies number of layers."""
@@ -301,7 +301,9 @@ class CNN_3D_XYZY_ModelConfig(ClassifierModelConfig):
             fingertip_config.num_pts_z,
         ]
 
-    def get_classifier_from_fingertip_config(self, fingertip_config: UnionFingertipConfig, n_tasks: int) -> Classifier:
+    def get_classifier_from_fingertip_config(
+        self, fingertip_config: UnionFingertipConfig, n_tasks: int
+    ) -> Classifier:
         """Helper method to return the correct classifier from config."""
 
         input_shape = self.input_shape_from_fingertip_config(fingertip_config)
@@ -316,7 +318,7 @@ class CNN_3D_XYZY_ModelConfig(ClassifierModelConfig):
 
 @dataclass(frozen=True)
 class CNN_3D_XYZXYZY_ModelConfig(ClassifierModelConfig):
-    """"Parameters for the CNN_3D_XYZXYZY_Classifier."""
+    """Parameters for the CNN_3D_XYZXYZY_Classifier."""
 
     conv_channels: List[int]
     """List of channels for each convolutional layer. Length specifies number of layers."""
@@ -338,7 +340,9 @@ class CNN_3D_XYZXYZY_ModelConfig(ClassifierModelConfig):
             fingertip_config.num_pts_z,
         ]
 
-    def get_classifier_from_fingertip_config(self, fingertip_config: UnionFingertipConfig, n_tasks: int) -> Classifier:
+    def get_classifier_from_fingertip_config(
+        self, fingertip_config: UnionFingertipConfig, n_tasks: int
+    ) -> Classifier:
         """Helper method to return the correct classifier from config."""
 
         input_shape = self.input_shape_from_fingertip_config(fingertip_config)
@@ -353,7 +357,7 @@ class CNN_3D_XYZXYZY_ModelConfig(ClassifierModelConfig):
 
 @dataclass(frozen=True)
 class CNN_3D_XYZXYZ_ModelConfig(ClassifierModelConfig):
-    """"Parameters for the CNN_3D_XYZXYZ_Classifier."""
+    """Parameters for the CNN_3D_XYZXYZ_Classifier."""
 
     conv_channels: List[int]
     """List of channels for each convolutional layer. Length specifies number of layers."""
@@ -374,7 +378,9 @@ class CNN_3D_XYZXYZ_ModelConfig(ClassifierModelConfig):
             fingertip_config.num_pts_z,
         ]
 
-    def get_classifier_from_fingertip_config(self, fingertip_config: UnionFingertipConfig, n_tasks: int) -> Classifier:
+    def get_classifier_from_fingertip_config(
+        self, fingertip_config: UnionFingertipConfig, n_tasks: int
+    ) -> Classifier:
         """Helper method to return the correct classifier from config."""
 
         input_shape = self.input_shape_from_fingertip_config(fingertip_config)
@@ -426,6 +432,7 @@ class CNN_3D_XYZ_ModelConfig(ClassifierModelConfig):
             mlp_hidden_layers=self.mlp_hidden_layers,
         )
 
+
 @dataclass(frozen=True)
 class CNN_3D_XYZ_Global_CNN_ModelConfig(ClassifierModelConfig):
     """Parameters for the CNN_3D_XYZ_Global_CNN_Classifier."""
@@ -466,9 +473,14 @@ class CNN_3D_XYZ_Global_CNN_ModelConfig(ClassifierModelConfig):
             n_tasks=n_tasks,
             conv_channels=self.conv_channels,
             mlp_hidden_layers=self.mlp_hidden_layers,
-            global_input_shape=(NERF_DENSITIES_GLOBAL_NUM_X, NERF_DENSITIES_GLOBAL_NUM_Y, NERF_DENSITIES_GLOBAL_NUM_Z),
+            global_input_shape=(
+                NERF_DENSITIES_GLOBAL_NUM_X,
+                NERF_DENSITIES_GLOBAL_NUM_Y,
+                NERF_DENSITIES_GLOBAL_NUM_Z,
+            ),
             global_conv_channels=self.global_conv_channels,
         )
+
 
 @dataclass(frozen=True)
 class CNN_3D_XYZ_Global_MLP_ModelConfig(ClassifierModelConfig):
@@ -510,7 +522,11 @@ class CNN_3D_XYZ_Global_MLP_ModelConfig(ClassifierModelConfig):
             n_tasks=n_tasks,
             conv_channels=self.conv_channels,
             mlp_hidden_layers=self.mlp_hidden_layers,
-            global_input_shape=(NERF_DENSITIES_GLOBAL_NUM_X*NERF_DENSITIES_GLOBAL_NUM_Y*NERF_DENSITIES_GLOBAL_NUM_Z,),
+            global_input_shape=(
+                NERF_DENSITIES_GLOBAL_NUM_X
+                * NERF_DENSITIES_GLOBAL_NUM_Y
+                * NERF_DENSITIES_GLOBAL_NUM_Z,
+            ),
             global_mlp_hidden_layers=self.global_mlp_hidden_layers,
         )
 
@@ -818,15 +834,17 @@ DEFAULTS_DICT = {
     ),
     "cnn-3d-xyz-global-cnn": ClassifierConfig(
         model_config=CNN_3D_XYZ_Global_CNN_ModelConfig(
-            conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256],
-            global_conv_channels=[32, 64, 128], global_mlp_hidden_layers=[256, 256]
+            conv_channels=[32, 64, 128],
+            mlp_hidden_layers=[256, 256],
+            global_conv_channels=[32, 64, 128],
         ),
         nerfdata_config=GridNerfDataConfig(),
     ),
     "cnn-3d-xyz-global-mlp": ClassifierConfig(
         model_config=CNN_3D_XYZ_Global_MLP_ModelConfig(
-            conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256],
-            global_mlp_hidden_layers=[256, 256]
+            conv_channels=[32, 64, 128],
+            mlp_hidden_layers=[256, 256],
+            global_mlp_hidden_layers=[256, 256],
         ),
         nerfdata_config=GridNerfDataConfig(),
     ),

--- a/nerf_grasping/config/classifier_config.py
+++ b/nerf_grasping/config/classifier_config.py
@@ -7,6 +7,8 @@ from nerf_grasping.classifier import (
     CNN_3D_XYZXYZY_Classifier,
     CNN_3D_XYZY_Classifier,
     CNN_3D_XYZ_Classifier,
+    CNN_3D_XYZ_Global_CNN_Classifier,
+    CNN_3D_XYZ_Global_MLP_Classifier,
     CNN_2D_1D_Classifier,
     Simple_CNN_2D_1D_Classifier,
     Simple_CNN_1D_2D_Classifier,
@@ -28,6 +30,12 @@ from nerf_grasping.config.nerfdata_config import (
     EvenlySpacedFingertipConfig,
     CameraConfig,
 )
+from nerf_grasping.dataset.nerf_densities_global_config import (
+    NERF_DENSITIES_GLOBAL_NUM_X,
+    NERF_DENSITIES_GLOBAL_NUM_Y,
+    NERF_DENSITIES_GLOBAL_NUM_Z,
+)
+
 from enum import Enum, auto
 import tyro
 import pathlib
@@ -418,6 +426,94 @@ class CNN_3D_XYZ_ModelConfig(ClassifierModelConfig):
             mlp_hidden_layers=self.mlp_hidden_layers,
         )
 
+@dataclass(frozen=True)
+class CNN_3D_XYZ_Global_CNN_ModelConfig(ClassifierModelConfig):
+    """Parameters for the CNN_3D_XYZ_Global_CNN_Classifier."""
+
+    conv_channels: List[int]
+    """List of channels for each convolutional layer. Length specifies number of layers."""
+
+    mlp_hidden_layers: List[int]
+    """List of hidden layer sizes for the MLP. Length specifies number of layers."""
+
+    global_conv_channels: List[int]
+    """List of channels for each convolutional layer for the global CNN. Length specifies number of layers."""
+
+    n_fingers: int = 4
+    """Number of fingers."""
+
+    def input_shape_from_fingertip_config(self, fingertip_config: UnionFingertipConfig):
+        n_density_channels = 1
+        n_xyz_channels = 3
+        return [
+            n_density_channels + n_xyz_channels,
+            fingertip_config.num_pts_x,
+            fingertip_config.num_pts_y,
+            fingertip_config.num_pts_z,
+        ]
+
+    def get_classifier_from_fingertip_config(
+        self,
+        fingertip_config: UnionFingertipConfig,
+        n_tasks: int,
+    ) -> Classifier:
+        """Helper method to return the correct classifier from config."""
+
+        input_shape = self.input_shape_from_fingertip_config(fingertip_config)
+        return CNN_3D_XYZ_Global_CNN_Classifier(
+            input_shape=input_shape,
+            n_fingers=fingertip_config.n_fingers,
+            n_tasks=n_tasks,
+            conv_channels=self.conv_channels,
+            mlp_hidden_layers=self.mlp_hidden_layers,
+            global_input_shape=(NERF_DENSITIES_GLOBAL_NUM_X, NERF_DENSITIES_GLOBAL_NUM_Y, NERF_DENSITIES_GLOBAL_NUM_Z),
+            global_conv_channels=self.global_conv_channels,
+        )
+
+@dataclass(frozen=True)
+class CNN_3D_XYZ_Global_MLP_ModelConfig(ClassifierModelConfig):
+    """Parameters for the CNN_3D_XYZ_Global_MLP_Classifier."""
+
+    conv_channels: List[int]
+    """List of channels for each convolutional layer. Length specifies number of layers."""
+
+    mlp_hidden_layers: List[int]
+    """List of hidden layer sizes for the MLP. Length specifies number of layers."""
+
+    global_mlp_hidden_layers: List[int]
+    """List of hidden layer sizes for the MLP for the global CNN. Length specifies number of layers."""
+
+    n_fingers: int = 4
+    """Number of fingers."""
+
+    def input_shape_from_fingertip_config(self, fingertip_config: UnionFingertipConfig):
+        n_density_channels = 1
+        n_xyz_channels = 3
+        return [
+            n_density_channels + n_xyz_channels,
+            fingertip_config.num_pts_x,
+            fingertip_config.num_pts_y,
+            fingertip_config.num_pts_z,
+        ]
+
+    def get_classifier_from_fingertip_config(
+        self,
+        fingertip_config: UnionFingertipConfig,
+        n_tasks: int,
+    ) -> Classifier:
+        """Helper method to return the correct classifier from config."""
+
+        input_shape = self.input_shape_from_fingertip_config(fingertip_config)
+        return CNN_3D_XYZ_Global_MLP_Classifier(
+            input_shape=input_shape,
+            n_fingers=fingertip_config.n_fingers,
+            n_tasks=n_tasks,
+            conv_channels=self.conv_channels,
+            mlp_hidden_layers=self.mlp_hidden_layers,
+            global_input_shape=(NERF_DENSITIES_GLOBAL_NUM_X*NERF_DENSITIES_GLOBAL_NUM_Y*NERF_DENSITIES_GLOBAL_NUM_Z,),
+            global_mlp_hidden_layers=self.global_mlp_hidden_layers,
+        )
+
 
 @dataclass(frozen=True)
 class CNN_2D_1D_ModelConfig(ClassifierModelConfig):
@@ -717,6 +813,20 @@ DEFAULTS_DICT = {
     "cnn-3d-xyz": ClassifierConfig(
         model_config=CNN_3D_XYZ_ModelConfig(
             conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256]
+        ),
+        nerfdata_config=GridNerfDataConfig(),
+    ),
+    "cnn-3d-xyz-global-cnn": ClassifierConfig(
+        model_config=CNN_3D_XYZ_Global_CNN_ModelConfig(
+            conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256],
+            global_conv_channels=[32, 64, 128], global_mlp_hidden_layers=[256, 256]
+        ),
+        nerfdata_config=GridNerfDataConfig(),
+    ),
+    "cnn-3d-xyz-global-mlp": ClassifierConfig(
+        model_config=CNN_3D_XYZ_Global_MLP_ModelConfig(
+            conv_channels=[32, 64, 128], mlp_hidden_layers=[256, 256],
+            global_mlp_hidden_layers=[256, 256]
         ),
         nerfdata_config=GridNerfDataConfig(),
     ),

--- a/nerf_grasping/config/classifier_config.py
+++ b/nerf_grasping/config/classifier_config.py
@@ -459,6 +459,16 @@ class CNN_3D_XYZ_Global_CNN_ModelConfig(ClassifierModelConfig):
             fingertip_config.num_pts_z,
         ]
 
+    def global_input_shape(self):
+        n_density_channels = 1
+        n_xyz_channels = 3
+        return (
+            n_density_channels + n_xyz_channels,
+            NERF_DENSITIES_GLOBAL_NUM_X,
+            NERF_DENSITIES_GLOBAL_NUM_Y,
+            NERF_DENSITIES_GLOBAL_NUM_Z,
+        )
+
     def get_classifier_from_fingertip_config(
         self,
         fingertip_config: UnionFingertipConfig,
@@ -467,17 +477,14 @@ class CNN_3D_XYZ_Global_CNN_ModelConfig(ClassifierModelConfig):
         """Helper method to return the correct classifier from config."""
 
         input_shape = self.input_shape_from_fingertip_config(fingertip_config)
+        global_input_shape = self.global_input_shape()
         return CNN_3D_XYZ_Global_CNN_Classifier(
             input_shape=input_shape,
             n_fingers=fingertip_config.n_fingers,
             n_tasks=n_tasks,
             conv_channels=self.conv_channels,
             mlp_hidden_layers=self.mlp_hidden_layers,
-            global_input_shape=(
-                NERF_DENSITIES_GLOBAL_NUM_X,
-                NERF_DENSITIES_GLOBAL_NUM_Y,
-                NERF_DENSITIES_GLOBAL_NUM_Z,
-            ),
+            global_input_shape=global_input_shape,
             global_conv_channels=self.global_conv_channels,
         )
 
@@ -508,6 +515,9 @@ class CNN_3D_XYZ_Global_MLP_ModelConfig(ClassifierModelConfig):
             fingertip_config.num_pts_z,
         ]
 
+    def global_input_shape(self):
+        return (NERF_DENSITIES_GLOBAL_NUM_X * NERF_DENSITIES_GLOBAL_NUM_Y * NERF_DENSITIES_GLOBAL_NUM_Z,)
+
     def get_classifier_from_fingertip_config(
         self,
         fingertip_config: UnionFingertipConfig,
@@ -516,17 +526,14 @@ class CNN_3D_XYZ_Global_MLP_ModelConfig(ClassifierModelConfig):
         """Helper method to return the correct classifier from config."""
 
         input_shape = self.input_shape_from_fingertip_config(fingertip_config)
+        global_input_shape = self.global_input_shape()
         return CNN_3D_XYZ_Global_MLP_Classifier(
             input_shape=input_shape,
             n_fingers=fingertip_config.n_fingers,
             n_tasks=n_tasks,
             conv_channels=self.conv_channels,
             mlp_hidden_layers=self.mlp_hidden_layers,
-            global_input_shape=(
-                NERF_DENSITIES_GLOBAL_NUM_X
-                * NERF_DENSITIES_GLOBAL_NUM_Y
-                * NERF_DENSITIES_GLOBAL_NUM_Z,
-            ),
+            global_input_shape=global_input_shape,
             global_mlp_hidden_layers=self.global_mlp_hidden_layers,
         )
 

--- a/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
+++ b/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
@@ -57,6 +57,8 @@ from nerf_grasping.dataset.nerf_densities_global_config import (
     NERF_DENSITIES_GLOBAL_NUM_X,
     NERF_DENSITIES_GLOBAL_NUM_Y,
     NERF_DENSITIES_GLOBAL_NUM_Z,
+    lb_Oy,
+    ub_Oy,
 )
 from nerf_grasping.config.base import CONFIG_DATETIME_STR
 from functools import partial
@@ -788,8 +790,6 @@ def get_nerf_densities(
             query_points_N = None
 
     with loop_timer.add_section_timer("get_densities_in_grid"):
-        lb_Oy = np.array([-0.2, -0.2, -0.2])
-        ub_Oy = np.array([0.2, 0.2, 0.2])
         lb_N = lb_Oy + X_N_Oy[:3, 3]
         ub_N = ub_Oy + X_N_Oy[:3, 3]
         nerf_densities_global, query_points_global_N = get_densities_in_grid(

--- a/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
+++ b/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
@@ -39,6 +39,8 @@ from nerf_grasping.dataset.DexGraspNet_NeRF_Grasps_utils import (
     plot_mesh_and_high_density_points,
     get_ray_samples_in_mesh_region,
     parse_object_code_and_scale,
+    transform_point,
+    transform_points,
 )
 from nerf_grasping.dataset.timers import LoopTimer
 from nerf_grasping.optimizer_utils import AllegroGraspConfig
@@ -790,8 +792,8 @@ def get_nerf_densities(
             query_points_N = None
 
     with loop_timer.add_section_timer("get_densities_in_grid"):
-        lb_N = lb_Oy + X_N_Oy[:3, 3]
-        ub_N = ub_Oy + X_N_Oy[:3, 3]
+        lb_N = transform_point(T=X_N_Oy, p=lb_Oy)
+        ub_N = transform_point(T=X_N_Oy, p=ub_Oy)
         nerf_densities_global, query_points_global_N = get_densities_in_grid(
             field=nerf_pipeline.model.field,
             lb=lb_N,
@@ -1189,7 +1191,9 @@ if cfg.plot_all_high_density_points:
     )
 
     X_Oy_N = np.linalg.inv(X_N_Oy)
-    query_points_global_Oy = query_points_global_N + X_Oy_N[:3, 3].reshape(1, 1, 1, 3)
+    query_points_global_Oy = transform_points(
+        T=X_Oy_N, points=query_points_global_N.reshape(-1, 3)
+    ).reshape(*query_points_global_N.shape)
     fig3 = plot_mesh_and_high_density_points(
         mesh=mesh_Oy,
         query_points=query_points_global_Oy.reshape(-1, 3),

--- a/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
+++ b/nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py
@@ -53,6 +53,11 @@ from nerf_grasping.nerf_utils import (
     get_densities_in_grid,
     render,
 )
+from nerf_grasping.dataset.nerf_densities_global_config import (
+    NERF_DENSITIES_GLOBAL_NUM_X,
+    NERF_DENSITIES_GLOBAL_NUM_Y,
+    NERF_DENSITIES_GLOBAL_NUM_Z,
+)
 from nerf_grasping.config.base import CONFIG_DATETIME_STR
 from functools import partial
 from nerf_grasping.config.nerfdata_config import (
@@ -97,13 +102,6 @@ tqdm = partial(std_tqdm, dynamic_ncols=True)
 
 
 # %%
-(
-    NERF_DENSITIES_GLOBAL_NUM_X,
-    NERF_DENSITIES_GLOBAL_NUM_Y,
-    NERF_DENSITIES_GLOBAL_NUM_Z,
-) = (40, 40, 40)
-
-
 @localscope.mfc
 def nerf_config_to_object_code_and_scale_str(nerf_config: pathlib.Path) -> str:
     # Input: PosixPath('2023-08-25_nerfcheckpoints/sem-Gun-4745991e7c0c7966a93f1ea6ebdeec6f_0_10/nerfacto/2023-08-25_132225/config.yml')

--- a/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
+++ b/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
@@ -56,6 +56,20 @@ def parse_object_code_and_scale(
     return object_code, object_scale
 
 
+def transform_point(T: np.ndarray, point: np.ndarray) -> np.ndarray:
+    assert T.shape == (4, 4), f"{T.shape}"
+    assert point.shape == (3,), f"{point.shape}"
+    return T[:3, :3] @ point + T[:3, 3]
+
+
+def transform_points(T: np.ndarray, points: np.ndarray) -> np.ndarray:
+    assert T.shape == (4, 4), f"{T.shape}"
+    N = points.shape[0]
+    assert points.shape == (N, 3), f"{points.shape}"
+
+    return (T[:3, :3] @ points.T + T[:3, 3][:, None]).T
+
+
 def get_scene_dict() -> Dict[str, Any]:
     return dict(
         xaxis=dict(title="X"),
@@ -284,6 +298,7 @@ def get_ray_samples_in_mesh_region(
         num_pts_y=num_pts_y,
         num_pts_z=num_pts_z,
     )
+
 
 def get_ray_samples_in_region(
     x_min: float,

--- a/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
+++ b/nerf_grasping/dataset/DexGraspNet_NeRF_Grasps_utils.py
@@ -214,13 +214,13 @@ def plot_mesh_and_query_points(
     fig.update_layout(
         legend_orientation="h",
         scene=dict(
-            xaxis=dict(nticks=4, range=[-0.2, 0.2]),
-            yaxis=dict(nticks=4, range=[-0.2, 0.2]),
-            zaxis=dict(nticks=4, range=[-0.2, 0.2]),
+            # xaxis=dict(nticks=4, range=[-0.3, 0.3]),
+            # yaxis=dict(nticks=4, range=[-0.3, 0.3]),
+            # zaxis=dict(nticks=4, range=[-0.3, 0.3]),
         ),
         title_text=title,
     )  # Avoid overlapping legend
-    fig.update_layout(scene_aspectmode="cube")
+    fig.update_layout(scene_aspectmode="data")
     return fig
 
 

--- a/nerf_grasping/dataset/nerf_densities_global_config.py
+++ b/nerf_grasping/dataset/nerf_densities_global_config.py
@@ -1,0 +1,6 @@
+# HACK: Just some hardcoded values to reference, make into nice config later
+(
+    NERF_DENSITIES_GLOBAL_NUM_X,
+    NERF_DENSITIES_GLOBAL_NUM_Y,
+    NERF_DENSITIES_GLOBAL_NUM_Z,
+) = (40, 40, 40)

--- a/nerf_grasping/dataset/nerf_densities_global_config.py
+++ b/nerf_grasping/dataset/nerf_densities_global_config.py
@@ -1,6 +1,12 @@
+import numpy as np
+
+
 # HACK: Just some hardcoded values to reference, make into nice config later
 (
     NERF_DENSITIES_GLOBAL_NUM_X,
     NERF_DENSITIES_GLOBAL_NUM_Y,
     NERF_DENSITIES_GLOBAL_NUM_Z,
 ) = (40, 40, 40)
+
+lb_Oy = np.array([-0.2, -0.2, -0.2])
+ub_Oy = np.array([0.2, 0.2, 0.2])

--- a/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
+++ b/nerf_grasping/learned_metric/DexGraspNet_batch_data.py
@@ -1,4 +1,14 @@
 from __future__ import annotations
+from nerf_grasping.nerf_utils import (
+    get_points_in_grid,
+)
+from nerf_grasping.dataset.nerf_densities_global_config import (
+    NERF_DENSITIES_GLOBAL_NUM_X,
+    NERF_DENSITIES_GLOBAL_NUM_Y,
+    NERF_DENSITIES_GLOBAL_NUM_Z,
+    lb_Oy,
+    ub_Oy,
+)
 import functools
 from dataclasses import dataclass
 import pypose as pp
@@ -51,6 +61,7 @@ class BatchDataInput:
     grasp_transforms: pp.LieTensor
     fingertip_config: BaseFingertipConfig  # have to take this because all these shape checks used to use hardcoded constants.
     grasp_configs: torch.Tensor
+    nerf_densities_global: Optional[torch.Tensor]
     object_y_wrt_table: Optional[torch.Tensor]
     random_rotate_transform: Optional[pp.LieTensor] = None
     nerf_density_threshold_value: Optional[float] = None
@@ -58,14 +69,16 @@ class BatchDataInput:
     def to(self, device) -> BatchDataInput:
         self.nerf_densities = self.nerf_densities.to(device)
         self.grasp_transforms = self.grasp_transforms.to(device)
+        self.grasp_configs = self.grasp_configs.to(device)
+        if self.nerf_densities_global is not None:
+            self.nerf_densities_global = self.nerf_densities_global.to(device)
+        if self.object_y_wrt_table is not None:
+            self.object_y_wrt_table = self.object_y_wrt_table.to(device)
         self.random_rotate_transform = (
             self.random_rotate_transform.to(device=device)
             if self.random_rotate_transform is not None
             else None
         )
-        self.grasp_configs = self.grasp_configs.to(device)
-        if self.object_y_wrt_table is not None:
-            self.object_y_wrt_table = self.object_y_wrt_table.to(device)
         return self
 
     @property
@@ -91,12 +104,74 @@ class BatchDataInput:
         return alphas
 
     @property
+    def nerf_alphas_global(self) -> torch.Tensor:
+        # alpha = 1 - exp(-delta * sigma)
+        #       = probability of collision within this segment starting from beginning of segment
+        delta = (
+            self.fingertip_config.grasp_depth_mm
+            / (self.fingertip_config.num_pts_z - 1)
+            / 1000
+        )
+        if isinstance(self.fingertip_config, EvenlySpacedFingertipConfig):
+            assert delta == self.fingertip_config.distance_between_pts_mm / 1000
+        alphas = 1.0 - torch.exp(-delta * self.nerf_densities_global)
+
+        if self.nerf_density_threshold_value is not None:
+            alphas = torch.where(
+                self.nerf_densities_global > self.nerf_density_threshold_value,
+                torch.ones_like(alphas),
+                torch.zeros_like(alphas),
+            )
+
+        return alphas
+
+    @property
     def coords(self) -> torch.Tensor:
         return self._coords_helper(self.grasp_transforms)
 
     @property
     def augmented_coords(self) -> torch.Tensor:
         return self._coords_helper(self.augmented_grasp_transforms)
+
+    @property
+    def coords_global(self) -> torch.Tensor:
+        points = get_points_in_grid(
+            lb=lb_Oy,
+            ub=ub_Oy,
+            num_x=NERF_DENSITIES_GLOBAL_NUM_X,
+            num_y=NERF_DENSITIES_GLOBAL_NUM_Y,
+            num_z=NERF_DENSITIES_GLOBAL_NUM_Z,
+        )
+
+        assert points.shape == (
+            NERF_DENSITIES_GLOBAL_NUM_X,
+            NERF_DENSITIES_GLOBAL_NUM_Y,
+            NERF_DENSITIES_GLOBAL_NUM_Z,
+            NUM_XYZ,
+        )
+        points = points.permute(3, 0, 1, 2)
+        points = points[None, ...].repeat_interleave(self.batch_size, dim=0)
+        assert points.shape == (
+            self.batch_size,
+            NUM_XYZ,
+            NERF_DENSITIES_GLOBAL_NUM_X,
+            NERF_DENSITIES_GLOBAL_NUM_Y,
+            NERF_DENSITIES_GLOBAL_NUM_Z,
+        )
+        return points
+
+    @property
+    def augmented_coords_global(self) -> torch.Tensor:
+        if self.random_rotate_transform is None:
+            return self.coords_global
+
+        # Unsqueeze because we're applying the same (single) random rotation to all fingers.
+        return_value = (
+            self.random_rotate_transform.rotation().unsqueeze(dim=1)
+            @ self.coords_global
+        )
+        assert return_value.shape == self.coords_global.shape
+        return return_value
 
     @property
     def coords_wrt_wrist(self) -> torch.Tensor:
@@ -167,6 +242,14 @@ class BatchDataInput:
             self.augmented_coords,
             self.augmented_coords_wrt_wrist,
         )
+
+    @property
+    def nerf_alphas_global_with_coords(self) -> torch.Tensor:
+        return self._nerf_alphas_global_with_coords_helper(self.coords_global)
+
+    @property
+    def nerf_alphas_global_with_augmented_coords(self) -> torch.Tensor:
+        return self._nerf_alphas_global_with_coords_helper(self.augmented_coords_global)
 
     @property
     def augmented_grasp_transforms(self) -> pp.LieTensor:
@@ -341,12 +424,11 @@ class BatchDataInput:
         )
 
         assert self.object_y_wrt_table is not None, "object_y_wrt_table is None"
-        assert self.object_y_wrt_table.shape == (
-            self.batch_size,
-        )
+        assert self.object_y_wrt_table.shape == (self.batch_size,)
         assert torch.all(self.object_y_wrt_table >= 0)
         y_coords_wrt_table = (
-            y_coords_wrt_object + self.object_y_wrt_table[..., None, None, None, None, None]
+            y_coords_wrt_object
+            + self.object_y_wrt_table[..., None, None, None, None, None]
         )
         return y_coords_wrt_table
 
@@ -537,6 +619,39 @@ class BatchDataInput:
             self.fingertip_config.num_pts_x,
             self.fingertip_config.num_pts_y,
             self.fingertip_config.num_pts_z,
+        )
+        return return_value
+
+    def _nerf_alphas_global_with_coords_helper(
+        self, coords_global: torch.Tensor
+    ) -> torch.Tensor:
+        assert coords_global.shape == (
+            self.batch_size,
+            NUM_XYZ,
+            NERF_DENSITIES_GLOBAL_NUM_X,
+            NERF_DENSITIES_GLOBAL_NUM_Y,
+            NERF_DENSITIES_GLOBAL_NUM_Z,
+        )
+        reshaped_nerf_alphas_global = self.nerf_alphas_global.reshape(
+            self.batch_size,
+            1,
+            NERF_DENSITIES_GLOBAL_NUM_X,
+            NERF_DENSITIES_GLOBAL_NUM_Y,
+            NERF_DENSITIES_GLOBAL_NUM_Z,
+        )
+        return_value = torch.cat(
+            [
+                reshaped_nerf_alphas_global,
+                coords_global,
+            ],
+            dim=1,
+        )
+        assert return_value.shape == (
+            self.batch_size,
+            NUM_XYZ + 1,
+            NERF_DENSITIES_GLOBAL_NUM_X,
+            NERF_DENSITIES_GLOBAL_NUM_Y,
+            NERF_DENSITIES_GLOBAL_NUM_Z,
         )
         return return_value
 

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -498,6 +498,7 @@ def custom_collate_fn(
     batch = torch.utils.data.dataloader.default_collate(batch)
     (
         nerf_densities,
+        nerf_densities_global,
         passed_simulation,
         passed_penetration_threshold,
         passed_eval,
@@ -506,6 +507,7 @@ def custom_collate_fn(
         grasp_configs,
         object_y_wrt_table,
     ) = batch
+    breakpoint()
 
     if debug_shuffle_labels:
         shuffle_inds = torch.randperm(passed_simulation.shape[0])
@@ -534,7 +536,7 @@ def custom_collate_fn(
             fingertip_config=fingertip_config,
             nerf_density_threshold_value=nerf_density_threshold_value,
             grasp_configs=grasp_configs,
-            nerf_densities_global=None,  # TODO: Implement this
+            nerf_densities_global=nerf_densities_global,
             object_y_wrt_table=object_y_wrt_table,
         ),
         output=BatchDataOutput(

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -534,6 +534,7 @@ def custom_collate_fn(
             fingertip_config=fingertip_config,
             nerf_density_threshold_value=nerf_density_threshold_value,
             grasp_configs=grasp_configs,
+            nerf_densities_global=None,  # TODO: Implement this
             object_y_wrt_table=object_y_wrt_table,
         ),
         output=BatchDataOutput(

--- a/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
+++ b/nerf_grasping/learned_metric/Train_DexGraspNet_NeRF_Grasp_Metric.py
@@ -507,7 +507,6 @@ def custom_collate_fn(
         grasp_configs,
         object_y_wrt_table,
     ) = batch
-    breakpoint()
 
     if debug_shuffle_labels:
         shuffle_inds = torch.randperm(passed_simulation.shape[0])

--- a/nerf_grasping/learned_metric/train_dataset.py
+++ b/nerf_grasping/learned_metric/train_dataset.py
@@ -25,6 +25,7 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
         max_num_data_points: Optional[int] = None,
         load_nerf_densities_in_ram: bool = False,
         load_nerf_densities_global_in_ram: bool = False,
+        load_nerf_densities_global_idx_in_ram: bool = False,
         load_grasp_labels_in_ram: bool = True,
         load_grasp_transforms_in_ram: bool = True,
         load_nerf_configs_in_ram: bool = True,
@@ -77,6 +78,12 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
                 torch.from_numpy(hdf5_file["/nerf_densities_global"][()]).float()
                 if load_nerf_densities_global_in_ram
                 and "nerf_densities_global" in hdf5_file
+                else None
+            )
+            self.nerf_densities_global_idx = (
+                torch.from_numpy(hdf5_file["/nerf_densities_global_idx"][()]).long()
+                if load_nerf_densities_global_idx_in_ram
+                and "nerf_densities_global_idx" in hdf5_file
                 else None
             )
 
@@ -170,13 +177,25 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
             if self.nerf_densities is None
             else self.nerf_densities[idx]
         )
+        nerf_densities_global_idx = (
+            torch.from_numpy(self.hdf5_file["/nerf_densities_global_idx"][idx]).long()
+            if self.nerf_densities_global_idx is None
+            and "nerf_densities_global_idx" in self.hdf5_file
+            else (
+                self.nerf_densities_global_idx[idx]
+                if self.nerf_densities_global_idx is not None
+                else None
+            )
+        )
         nerf_densities_global = (
-            torch.from_numpy(self.hdf5_file["/nerf_densities_global"][idx]).float()
+            torch.from_numpy(self.hdf5_file["/nerf_densities_global"][nerf_densities_global_idx]).float()
             if self.nerf_densities_global is None
             and "nerf_densities_global" in self.hdf5_file
+            and nerf_densities_global_idx is not None
             else (
-                self.nerf_densities_global[idx]
+                self.nerf_densities_global[nerf_densities_global_idx]
                 if self.nerf_densities_global is not None
+                and nerf_densities_global_idx is not None
                 else None
             )
         )

--- a/nerf_grasping/learned_metric/train_dataset.py
+++ b/nerf_grasping/learned_metric/train_dataset.py
@@ -6,6 +6,11 @@ import h5py
 import pypose as pp
 from nerf_grasping.config.fingertip_config import BaseFingertipConfig
 from nerf_grasping.config.camera_config import CameraConfig
+from nerf_grasping.dataset.nerf_densities_global_config import (
+    NERF_DENSITIES_GLOBAL_NUM_X,
+    NERF_DENSITIES_GLOBAL_NUM_Y,
+    NERF_DENSITIES_GLOBAL_NUM_Z,
+)
 
 
 # Make atol and rtol larger than default to avoid errors due to floating point precision.
@@ -178,7 +183,7 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
             else self.nerf_densities[idx]
         )
         nerf_densities_global_idx = (
-            torch.from_numpy(self.hdf5_file["/nerf_densities_global_idx"][idx]).long()
+            self.hdf5_file["/nerf_densities_global_idx"][idx]
             if self.nerf_densities_global_idx is None
             and "nerf_densities_global_idx" in self.hdf5_file
             else (
@@ -268,7 +273,7 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
         if nerf_densities_global is not None:
             assert_equals(
                 nerf_densities_global.shape,
-                (self.NUM_PTS_X, self.NUM_PTS_Y, self.NUM_PTS_Z),
+                (NERF_DENSITIES_GLOBAL_NUM_X, NERF_DENSITIES_GLOBAL_NUM_Y, NERF_DENSITIES_GLOBAL_NUM_Z),
             )
         NUM_CLASSES = 2
         assert_equals(passed_simulation.shape, (NUM_CLASSES,))
@@ -279,13 +284,8 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
         assert_equals(object_scale.shape, ())
         assert_equals(object_state.shape, (13,))
 
-        # BRITTLE: hardcoding buffer, exclude table thickness, so this is wrt table surface
-        BUFFER = 1.2
-        OBJ_MAX_EXTENT_FROM_ORIGIN = 1.0 * object_scale * BUFFER
-        y_offset = OBJ_MAX_EXTENT_FROM_ORIGIN
-        object_y = object_state[1]
-        object_y_wrt_table = y_offset - object_y
-        assert object_y_wrt_table >= 0
+        # TODO: Populate this better using X_N_Oy
+        object_y_wrt_table = -2
 
         return (
             nerf_densities,

--- a/nerf_grasping/learned_metric/train_dataset.py
+++ b/nerf_grasping/learned_metric/train_dataset.py
@@ -284,8 +284,10 @@ class NeRFGrid_To_GraspSuccess_HDF5_Dataset(Dataset):
         assert_equals(object_scale.shape, ())
         assert_equals(object_state.shape, (13,))
 
-        # TODO: Populate this better using X_N_Oy
-        object_y_wrt_table = -2
+        # BRITTLE: Assumes that object_state is given in a frame such that y=0 is the table surface
+        object_y = object_state[1]
+        object_y_wrt_table = object_y
+        assert object_y_wrt_table >= 0
 
         return (
             nerf_densities,

--- a/nerf_grasping/models/dexgraspnet_models.py
+++ b/nerf_grasping/models/dexgraspnet_models.py
@@ -345,6 +345,16 @@ class CNN_3D_MLP_Model(nn.Module):
             ),
         )
 
+        x = torch.cat([x, global_x], dim=1)
+        assert_equals(
+            x.shape,
+            (
+                batch_size,
+                self.n_fingers * self.conv_output_dim
+                + self.global_mlp_hidden_layers[-1],
+            ),
+        )
+
         all_logits = self.mlp(x)
         assert_equals(all_logits.shape, (batch_size, self.n_classes * self.n_tasks))
         all_logits = all_logits.reshape(batch_size, self.n_tasks, self.n_classes)

--- a/nerf_grasping/models/dexgraspnet_models.py
+++ b/nerf_grasping/models/dexgraspnet_models.py
@@ -101,6 +101,259 @@ class CNN_3D_Model(nn.Module):
         return self(x)
 
 
+class CNN_3D_CNN_3D_Model(nn.Module):
+    def __init__(
+        self,
+        input_shape: Tuple[int, int, int, int],
+        conv_channels: Tuple[int, ...],
+        mlp_hidden_layers: Tuple[int, ...],
+        global_input_shape: Tuple[int, int, int, int],
+        global_conv_channels: Tuple[int, ...],
+        n_fingers: int,
+        n_tasks: int = 1,
+        n_classes: int = 2,
+    ) -> None:
+        super().__init__()
+        self.input_shape = input_shape
+        self.global_input_shape = global_input_shape
+        self.n_fingers = n_fingers
+        self.n_tasks = n_tasks
+        self.n_classes = n_classes
+
+        # Conv
+        self.conv = conv_encoder(
+            input_shape=self.input_shape,
+            conv_channels=conv_channels,
+            pool_type=PoolType.MAX,
+            dropout_prob=0.1,
+            conv_output_to_1d=ConvOutputTo1D.AVG_POOL_SPATIAL,
+        )
+
+        # Get conv output shape
+        example_batch_size = 2
+        example_input = torch.zeros(
+            example_batch_size, self.n_fingers, *self.input_shape
+        )
+        example_input = example_input.reshape(
+            example_batch_size * self.n_fingers, *self.input_shape
+        )
+        conv_output = self.conv(example_input)
+        self.conv_output_dim = conv_output.shape[-1]
+        assert_equals(
+            conv_output.shape,
+            (
+                example_batch_size * self.n_fingers,
+                self.conv_output_dim,
+            ),
+        )
+
+        # Global Conv
+        self.global_conv = conv_encoder(
+            input_shape=self.global_input_shape,
+            conv_channels=global_conv_channels,
+            pool_type=PoolType.MAX,
+            dropout_prob=0.1,
+            conv_output_to_1d=ConvOutputTo1D.AVG_POOL_SPATIAL,
+        )
+
+        # Get global conv output shape
+        example_batch_size = 2
+        example_input = torch.zeros(example_batch_size, *self.global_input_shape)
+        global_conv_output = self.global_conv(example_input)
+        self.global_conv_output_dim = global_conv_output.shape[-1]
+        assert_equals(
+            global_conv_output.shape,
+            (
+                example_batch_size,
+                self.global_conv_output_dim,
+            ),
+        )
+
+        # MLP
+        self.mlp = mlp(
+            num_inputs=self.conv_output_dim * self.n_fingers
+            + self.global_conv_output_dim,
+            num_outputs=self.n_classes * self.n_tasks,
+            hidden_layers=mlp_hidden_layers,
+        )
+
+    def forward(self, x: torch.Tensor, global_x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.shape[0]
+        assert_equals(
+            x.shape,
+            (
+                batch_size,
+                self.n_fingers,
+                *self.input_shape,
+            ),
+        )
+        assert_equals(
+            global_x.shape,
+            (
+                batch_size,
+                *self.global_input_shape,
+            ),
+        )
+
+        # Put n_fingers into batch dim
+        x = x.reshape(batch_size * self.n_fingers, *self.input_shape)
+
+        x = self.conv(x)
+        assert_equals(
+            x.shape,
+            (
+                batch_size * self.n_fingers,
+                self.conv_output_dim,
+            ),
+        )
+        x = x.reshape(batch_size, self.n_fingers, self.conv_output_dim)
+        x = x.reshape(batch_size, self.n_fingers * self.conv_output_dim)
+
+        global_x = self.global_conv(global_x)
+        assert_equals(
+            global_x.shape,
+            (
+                batch_size,
+                self.global_conv_output_dim,
+            ),
+        )
+
+        x = torch.cat([x, global_x], dim=1)
+        assert_equals(
+            x.shape,
+            (
+                batch_size,
+                self.n_fingers * self.conv_output_dim + self.global_conv_output_dim,
+            ),
+        )
+
+        all_logits = self.mlp(x)
+        assert_equals(all_logits.shape, (batch_size, self.n_classes * self.n_tasks))
+        all_logits = all_logits.reshape(batch_size, self.n_tasks, self.n_classes)
+        return all_logits
+
+    def get_all_logits(self, x: torch.Tensor) -> torch.Tensor:
+        return self(x)
+
+
+class CNN_3D_MLP_Model(nn.Module):
+    def __init__(
+        self,
+        input_shape: Tuple[int, int, int, int],
+        conv_channels: Tuple[int, ...],
+        mlp_hidden_layers: Tuple[int, ...],
+        global_input_shape: Tuple[int],
+        global_mlp_hidden_layers: Tuple[int, ...],
+        n_fingers: int,
+        n_tasks: int = 1,
+        n_classes: int = 2,
+    ) -> None:
+        super().__init__()
+        self.input_shape = input_shape
+        self.global_input_shape = global_input_shape
+        self.global_mlp_hidden_layers = global_mlp_hidden_layers
+        self.n_fingers = n_fingers
+        self.n_tasks = n_tasks
+        self.n_classes = n_classes
+
+        # Conv
+        self.conv = conv_encoder(
+            input_shape=self.input_shape,
+            conv_channels=conv_channels,
+            pool_type=PoolType.MAX,
+            dropout_prob=0.1,
+            conv_output_to_1d=ConvOutputTo1D.AVG_POOL_SPATIAL,
+        )
+
+        # Get conv output shape
+        example_batch_size = 2
+        example_input = torch.zeros(
+            example_batch_size, self.n_fingers, *self.input_shape
+        )
+        example_input = example_input.reshape(
+            example_batch_size * self.n_fingers, *self.input_shape
+        )
+        conv_output = self.conv(example_input)
+        self.conv_output_dim = conv_output.shape[-1]
+        assert_equals(
+            conv_output.shape,
+            (
+                example_batch_size * self.n_fingers,
+                self.conv_output_dim,
+            ),
+        )
+
+        # Global MLP
+        assert (
+            len(self.global_input_shape) == 1
+        ), f"self.global_input_shape: {self.global_input_shape}"
+        assert (
+            len(global_mlp_hidden_layers) > 0
+        ), f"global_mlp_hidden_layers: {global_mlp_hidden_layers}"
+        self.global_mlp = mlp(
+            num_inputs=self.global_input_shape[0],
+            num_outputs=global_mlp_hidden_layers[-1],
+            hidden_layers=global_mlp_hidden_layers[:-1],
+        )
+
+        # MLP
+        self.mlp = mlp(
+            num_inputs=self.conv_output_dim * self.n_fingers
+            + global_mlp_hidden_layers[-1],
+            num_outputs=self.n_classes * self.n_tasks,
+            hidden_layers=mlp_hidden_layers,
+        )
+
+    def forward(self, x: torch.Tensor, global_x: torch.Tensor) -> torch.Tensor:
+        batch_size = x.shape[0]
+        assert_equals(
+            x.shape,
+            (
+                batch_size,
+                self.n_fingers,
+                *self.input_shape,
+            ),
+        )
+        assert_equals(
+            global_x.shape,
+            (
+                batch_size,
+                *self.global_input_shape,
+            ),
+        )
+
+        # Put n_fingers into batch dim
+        x = x.reshape(batch_size * self.n_fingers, *self.input_shape)
+
+        x = self.conv(x)
+        assert_equals(
+            x.shape,
+            (
+                batch_size * self.n_fingers,
+                self.conv_output_dim,
+            ),
+        )
+        x = x.reshape(batch_size, self.n_fingers, self.conv_output_dim)
+        x = x.reshape(batch_size, self.n_fingers * self.conv_output_dim)
+
+        global_x = self.global_mlp(global_x)
+        assert_equals(
+            global_x.shape,
+            (
+                batch_size,
+                self.global_mlp_hidden_layers[-1],
+            ),
+        )
+
+        all_logits = self.mlp(x)
+        assert_equals(all_logits.shape, (batch_size, self.n_classes * self.n_tasks))
+        all_logits = all_logits.reshape(batch_size, self.n_tasks, self.n_classes)
+        return all_logits
+
+    def get_all_logits(self, x: torch.Tensor) -> torch.Tensor:
+        return self(x)
+
+
 class CNN_2D_1D_Model(nn.Module):
     def __init__(
         self,
@@ -676,13 +929,13 @@ class DepthImage_CNN_2D_Model(nn.Module):
         x = x.reshape(batch_size * n_fingers * C, 1, H, W)
         conditioning = conditioning.reshape(batch_size * n_fingers, conditioning_dim)
         conditioning_repeated = conditioning.repeat_interleave(C, dim=0)
-        assert_equals(conditioning_repeated.shape, (batch_size * n_fingers * C, conditioning_dim))
+        assert_equals(
+            conditioning_repeated.shape, (batch_size * n_fingers * C, conditioning_dim)
+        )
 
         # Conv 2D
         x = self.conv_2d(x, conditioning=conditioning_repeated)
-        assert_equals(
-            x.shape, (batch_size * n_fingers * C, self.conv_2d.output_dim())
-        )
+        assert_equals(x.shape, (batch_size * n_fingers * C, self.conv_2d.output_dim()))
 
         # Aggregate into one feature dimension
         x = x.reshape(batch_size, n_fingers * C * self.conv_2d.output_dim())
@@ -694,7 +947,8 @@ class DepthImage_CNN_2D_Model(nn.Module):
             x.shape,
             (
                 batch_size,
-                n_fingers * self.conv_2d.output_dim() * C + n_fingers * conditioning_dim,
+                n_fingers * self.conv_2d.output_dim() * C
+                + n_fingers * conditioning_dim,
             ),
         )
 

--- a/nerf_grasping/models/dexgraspnet_models.py
+++ b/nerf_grasping/models/dexgraspnet_models.py
@@ -232,8 +232,8 @@ class CNN_3D_CNN_3D_Model(nn.Module):
         all_logits = all_logits.reshape(batch_size, self.n_tasks, self.n_classes)
         return all_logits
 
-    def get_all_logits(self, x: torch.Tensor) -> torch.Tensor:
-        return self(x)
+    def get_all_logits(self, x: torch.Tensor, global_x: torch.Tensor) -> torch.Tensor:
+        return self(x, global_x)
 
 
 class CNN_3D_MLP_Model(nn.Module):
@@ -350,8 +350,8 @@ class CNN_3D_MLP_Model(nn.Module):
         all_logits = all_logits.reshape(batch_size, self.n_tasks, self.n_classes)
         return all_logits
 
-    def get_all_logits(self, x: torch.Tensor) -> torch.Tensor:
-        return self(x)
+    def get_all_logits(self, x: torch.Tensor, global_x: torch.Tensor) -> torch.Tensor:
+        return self(x, global_x)
 
 
 class CNN_2D_1D_Model(nn.Module):

--- a/nerf_grasping/nerf_utils.py
+++ b/nerf_grasping/nerf_utils.py
@@ -205,18 +205,14 @@ def _render_depth_and_uncertainty_for_single_ray_bundle(
     return depth, depth_variance
 
 
-def compute_centroid_from_nerf(
+def get_densities_in_grid(
     field: Field,
     lb: np.ndarray,
     ub: np.ndarray,
-    level: float,
     num_pts_x: int,
     num_pts_y: int,
     num_pts_z: int,
-) -> np.ndarray:
-    """
-    Compute the centroid of the field.
-    """
+) -> Tuple[np.ndarray, np.ndarray]:
     x_min, y_min, z_min = lb
     x_max, y_max, z_max = ub
     ray_samples_in_region = get_ray_samples_in_region(
@@ -252,9 +248,32 @@ def compute_centroid_from_nerf(
             num_pts_z,
         )
     )
+    return nerf_densities_in_region, query_points_in_region
+
+
+def compute_centroid_from_nerf(
+    field: Field,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    level: float,
+    num_pts_x: int,
+    num_pts_y: int,
+    num_pts_z: int,
+) -> np.ndarray:
+    """
+    Compute the centroid of the field.
+    """
+    nerf_densities_in_region, query_points_in_region = get_densities_in_grid(
+        field=field,
+        lb=lb,
+        ub=ub,
+        num_pts_x=num_pts_x,
+        num_pts_y=num_pts_y,
+        num_pts_z=num_pts_z,
+    )
 
     points_to_keep_with_nans = np.where(
-        (nerf_densities_in_region > 15)[..., None].repeat(3, axis=-1),
+        (nerf_densities_in_region > level)[..., None].repeat(3, axis=-1),
         query_points_in_region,
         np.nan,
     )

--- a/nerf_grasping/nerf_utils.py
+++ b/nerf_grasping/nerf_utils.py
@@ -205,14 +205,13 @@ def _render_depth_and_uncertainty_for_single_ray_bundle(
     return depth, depth_variance
 
 
-def get_densities_in_grid(
-    field: Field,
+def get_points_in_grid(
     lb: np.ndarray,
     ub: np.ndarray,
     num_pts_x: int,
     num_pts_y: int,
     num_pts_z: int,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> np.ndarray:
     x_min, y_min, z_min = lb
     x_max, y_max, z_max = ub
     x_coords = np.linspace(x_min, x_max, num_pts_x)
@@ -221,6 +220,25 @@ def get_densities_in_grid(
 
     xx, yy, zz = np.meshgrid(x_coords, y_coords, z_coords, indexing="ij")
     query_points_in_region = np.stack([xx, yy, zz], axis=-1)
+    assert query_points_in_region.shape == (num_pts_x, num_pts_y, num_pts_z, 3)
+    return query_points_in_region
+
+
+def get_densities_in_grid(
+    field: Field,
+    lb: np.ndarray,
+    ub: np.ndarray,
+    num_pts_x: int,
+    num_pts_y: int,
+    num_pts_z: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    query_points_in_region = get_points_in_grid(
+        lb=lb,
+        ub=ub,
+        num_pts_x=num_pts_x,
+        num_pts_y=num_pts_y,
+        num_pts_z=num_pts_z,
+    )
     assert query_points_in_region.shape == (num_pts_x, num_pts_y, num_pts_z, 3)
 
     nerf_densities_in_region = (

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -700,6 +700,7 @@ class GraspMetric(torch.nn.Module):
             grasp_transforms=grasp_config.grasp_frame_transforms,
             fingertip_config=self.fingertip_config,
             grasp_configs=grasp_config.as_tensor(),
+            nerf_densities_global=None,  # ? NEED TO PASS THIS IN?
             object_y_wrt_table=None,  # ? NEED TO PASS THIS IN?
         ).to(grasp_config.hand_config.wrist_pose.device)
 

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -21,15 +21,26 @@ from nerf_grasping.learned_metric.DexGraspNet_batch_data import (
     BatchDataInput,
     DepthImageBatchDataInput,
 )
+from nerf_grasping.dataset.DexGraspNet_NeRF_Grasps_utils import (
+    transform_point,
+)
 from nerf_grasping.nerf_utils import (
     get_cameras,
     render,
+    get_densities_in_grid,
 )
 from nerf_grasping.config.grasp_metric_config import GraspMetricConfig
 from nerf_grasping.config.fingertip_config import UnionFingertipConfig
 from nerf_grasping.config.camera_config import CameraConfig
 from nerf_grasping.config.classifier_config import ClassifierConfig
 from nerf_grasping.config.nerfdata_config import DepthImageNerfDataConfig
+from nerf_grasping.dataset.nerf_densities_global import (
+    NERF_DENSITIES_GLOBAL_NUM_X,
+    NERF_DENSITIES_GLOBAL_NUM_Y,
+    NERF_DENSITIES_GLOBAL_NUM_Z,
+    lb_Oy,
+    ub_Oy,
+)
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from contextlib import nullcontext
@@ -684,13 +695,25 @@ class GraspMetric(torch.nn.Module):
         densities = self.compute_nerf_densities(
             ray_samples,
         )
-
         assert densities.shape == (
             grasp_config.batch_size,
             4,
             self.fingertip_config.num_pts_x,
             self.fingertip_config.num_pts_y,
             self.fingertip_config.num_pts_z,
+        )
+
+        # Query NeRF in grid
+        # TODO: Make it check if it's needed to save time
+        lb_N = transform_point(T=self.X_N_Oy, p=lb_Oy)
+        ub_N = transform_point(T=self.X_N_Oy, p=ub_Oy)
+        nerf_densities_global, query_points_global_N = get_densities_in_grid(
+            field=self.nerf_field,
+            lb=lb_N,
+            ub=ub_N,
+            num_pts_x=NERF_DENSITIES_GLOBAL_NUM_X,
+            num_pts_y=NERF_DENSITIES_GLOBAL_NUM_Y,
+            num_pts_z=NERF_DENSITIES_GLOBAL_NUM_Z,
         )
 
         # HACK: NOT SURE HOW TO FILL THIS
@@ -700,7 +723,7 @@ class GraspMetric(torch.nn.Module):
             grasp_transforms=grasp_config.grasp_frame_transforms,
             fingertip_config=self.fingertip_config,
             grasp_configs=grasp_config.as_tensor(),
-            nerf_densities_global=None,  # ? NEED TO PASS THIS IN?
+            nerf_densities_global=nerf_densities_global,  # ? NEED TO PASS THIS IN?
             object_y_wrt_table=None,  # ? NEED TO PASS THIS IN?
         ).to(grasp_config.hand_config.wrist_pose.device)
 

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -34,7 +34,7 @@ from nerf_grasping.config.fingertip_config import UnionFingertipConfig
 from nerf_grasping.config.camera_config import CameraConfig
 from nerf_grasping.config.classifier_config import ClassifierConfig
 from nerf_grasping.config.nerfdata_config import DepthImageNerfDataConfig
-from nerf_grasping.dataset.nerf_densities_global import (
+from nerf_grasping.dataset.nerf_densities_global_config import (
     NERF_DENSITIES_GLOBAL_NUM_X,
     NERF_DENSITIES_GLOBAL_NUM_Y,
     NERF_DENSITIES_GLOBAL_NUM_Z,
@@ -705,7 +705,9 @@ class GraspMetric(torch.nn.Module):
 
         # Query NeRF in grid
         # BRITTLE: Require that the classifier_model has the word "Global" in it if needed
-        need_to_query_global = "global" in self.classifier_model.__class__.__name__.lower()
+        need_to_query_global = (
+            "global" in self.classifier_model.__class__.__name__.lower()
+        )
         if need_to_query_global:
             lb_N = transform_point(T=self.X_N_Oy, p=lb_Oy)
             ub_N = transform_point(T=self.X_N_Oy, p=ub_Oy)
@@ -728,7 +730,9 @@ class GraspMetric(torch.nn.Module):
             grasp_transforms=grasp_config.grasp_frame_transforms,
             fingertip_config=self.fingertip_config,
             grasp_configs=grasp_config.as_tensor(),
-            nerf_densities_global=nerf_densities_global if nerf_densities_global is not None else None,
+            nerf_densities_global=(
+                nerf_densities_global if nerf_densities_global is not None else None
+            ),
             object_y_wrt_table=None,  # ? NEED TO PASS THIS IN?
         ).to(grasp_config.hand_config.wrist_pose.device)
 

--- a/nerf_grasping/optimizer_utils.py
+++ b/nerf_grasping/optimizer_utils.py
@@ -709,8 +709,8 @@ class GraspMetric(torch.nn.Module):
             "global" in self.classifier_model.__class__.__name__.lower()
         )
         if need_to_query_global:
-            lb_N = transform_point(T=self.X_N_Oy, p=lb_Oy)
-            ub_N = transform_point(T=self.X_N_Oy, p=ub_Oy)
+            lb_N = transform_point(T=self.X_N_Oy, point=lb_Oy)
+            ub_N = transform_point(T=self.X_N_Oy, point=ub_Oy)
             nerf_densities_global, query_points_global_N = get_densities_in_grid(
                 field=self.nerf_field,
                 lb=lb_N,
@@ -719,7 +719,11 @@ class GraspMetric(torch.nn.Module):
                 num_pts_y=NERF_DENSITIES_GLOBAL_NUM_Y,
                 num_pts_z=NERF_DENSITIES_GLOBAL_NUM_Z,
             )
-            nerf_densities_global = torch.from_numpy(nerf_densities_global).float()
+            nerf_densities_global = (
+                torch.from_numpy(nerf_densities_global)
+                .float()[None, ...]
+                .repeat_interleave(grasp_config.batch_size, dim=0)
+            )
         else:
             nerf_densities_global = None
 

--- a/nerf_grasping/run_pipeline.py
+++ b/nerf_grasping/run_pipeline.py
@@ -1365,6 +1365,7 @@ def main() -> None:
             collision_check_table=True,
             use_cuda_graph=True,
             collision_sphere_buffer=0.01,
+            warmup=False,  # Warmup amortizes the cost of subsequent calls, but takes longer overall, no help in serial program
         )
     )
     (
@@ -1382,6 +1383,7 @@ def main() -> None:
         collision_check_table=True,
         use_cuda_graph=True,
         collision_sphere_buffer=0.01,
+        warmup=False,  # Warmup amortizes the cost of subsequent calls, but takes longer overall, no help in serial program
     )
     end_prepare_trajopt_batch = time.time()
     print("@" * 80)

--- a/prepare_dgn_experiment.py
+++ b/prepare_dgn_experiment.py
@@ -25,6 +25,7 @@ class Args:
     nerf_grasping_data_path: pathlib.Path = (
         pathlib.Path(nerf_grasping.get_repo_root()).resolve() / "data"
     )
+    evaled_grasp_config_dicts_foldername: str = "evaled_grasp_config_dicts"
 
 
 def print_and_run(cmd: str) -> None:
@@ -74,7 +75,7 @@ def main() -> None:
         print_and_run(f"ln -sr {experiment_path} {new_experiment_path}")
 
     # Create train/val/test split
-    evaled_grasp_config_dicts_path = new_experiment_path / "evaled_grasp_config_dicts"
+    evaled_grasp_config_dicts_path = new_experiment_path / args.evaled_grasp_config_dicts_foldername
     assert (
         evaled_grasp_config_dicts_path.exists()
     ), f"{evaled_grasp_config_dicts_path} does not exist"
@@ -98,14 +99,23 @@ def main() -> None:
     test_filenames = filenames[n_train + n_val :]
 
     # Create symlinks to train/val/test split
+    evaled_grasp_config_dicts_train_foldername = (
+        f"{args.evaled_grasp_config_dicts_foldername}_train"
+    )
+    evaled_grasp_config_dicts_val_foldername = (
+        f"{args.evaled_grasp_config_dicts_foldername}_val"
+    )
+    evaled_grasp_config_dicts_test_foldername = (
+        f"{args.evaled_grasp_config_dicts_foldername}_test"
+    )
     evaled_grasp_config_dicts_train_path = (
-        new_experiment_path / "evaled_grasp_config_dicts_train"
+        new_experiment_path / evaled_grasp_config_dicts_train_foldername
     )
     evaled_grasp_config_dicts_val_path = (
-        new_experiment_path / "evaled_grasp_config_dicts_val"
+        new_experiment_path / evaled_grasp_config_dicts_val_foldername
     )
     evaled_grasp_config_dicts_test_path = (
-        new_experiment_path / "evaled_grasp_config_dicts_test"
+        new_experiment_path / evaled_grasp_config_dicts_test_foldername
     )
 
     for new_path, filenames in [
@@ -131,21 +141,21 @@ def main() -> None:
     if args.create_grid_dataset:
         print_and_run(
             f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
-            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_train'}"
+            + f" --evaled-grasp-config-dicts-path {new_experiment_path / evaled_grasp_config_dicts_train_foldername}"
             + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
             + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'train_dataset.h5'}"
         )
         if n_val > 0:
             print_and_run(
                 f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
-                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_val'}"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / evaled_grasp_config_dicts_val_foldername}"
                 + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
                 + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'val_dataset.h5'}"
             )
         if n_test > 0:
             print_and_run(
                 f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py grid"
-                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_test'}"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / evaled_grasp_config_dicts_test_foldername}"
                 + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
                 + f" --output-filepath {new_experiment_path / 'grid_dataset' / 'test_dataset.h5'}"
             )
@@ -154,21 +164,21 @@ def main() -> None:
     if args.create_depth_image_dataset:
         print_and_run(
             f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
-            + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_train'}"
+            + f" --evaled-grasp-config-dicts-path {new_experiment_path / evaled_grasp_config_dicts_train_foldername}"
             + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
             + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'train_dataset.h5'}"
         )
         if n_val > 0:
             print_and_run(
                 f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
-                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_val'}"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / evaled_grasp_config_dicts_val_foldername}"
                 + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
                 + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'val_dataset.h5'}"
             )
         if n_test > 0:
             print_and_run(
                 f"python nerf_grasping/dataset/Create_DexGraspNet_NeRF_Grasps_Dataset.py depth-image"
-                + f" --evaled-grasp-config-dicts-path {new_experiment_path / 'evaled_grasp_config_dicts_test'}"
+                + f" --evaled-grasp-config-dicts-path {new_experiment_path / evaled_grasp_config_dicts_test_foldername}"
                 + f" --nerf-checkpoints-path {new_experiment_path / 'nerfcheckpoints'}"
                 + f" --output-filepath {new_experiment_path / 'depth_image_dataset' / 'test_dataset.h5'}"
             )

--- a/tyler_scratch/TYLER_SCRATCH_62_debug_dataset.py
+++ b/tyler_scratch/TYLER_SCRATCH_62_debug_dataset.py
@@ -1,0 +1,223 @@
+# %%
+import h5py
+import pathlib
+import trimesh
+import numpy as np
+import plotly.graph_objects as go
+import pypose as pp
+import torch
+from nerf_grasping import grasp_utils
+from nerf_grasping.config.fingertip_config import EvenlySpacedFingertipConfig
+
+# %%
+file = h5py.File(
+    "/home/tylerlum/2024-05-09_rotated_stable_grasps_noisy_TUNED/grid_dataset/train_dataset.h5",
+    "r",
+)
+
+# %%
+file.attrs["num_data_points"]
+
+# %%
+GRASP_IDX = 15346
+assert GRASP_IDX < file.attrs["num_data_points"]
+
+# %%
+file["/passed_simulation"][()].shape
+
+# %%
+file["/passed_penetration_threshold"][()].shape
+
+# %%
+file["/passed_eval"][()].shape
+
+# %%
+file["/nerf_densities"].shape
+
+# %%
+file["/nerf_densities"][GRASP_IDX].shape
+
+# %%
+file["/nerf_densities_global_idx"].shape
+
+# %%
+object_idx = file["/nerf_densities_global_idx"][GRASP_IDX]
+print(f"Object idx: {object_idx}")
+
+# %%
+file["/nerf_densities_global"].shape
+
+# %%
+file["/nerf_densities_global"][object_idx].shape
+
+
+# %%
+file.keys()
+
+# %%
+file["/object_code"][GRASP_IDX].decode("utf-8")
+
+# %%
+# Extract mesh info
+object_code = file["/object_code"][GRASP_IDX].decode("utf-8")
+object_scale = file["/object_scale"][GRASP_IDX]
+
+object_path = (
+    pathlib.Path("/juno/u/tylerlum/github_repos/DexGraspNet/data/rotated_meshdata_v2")
+    / object_code
+    / "coacd"
+    / "decomposed.obj"
+)
+assert object_path.exists()
+mesh_Oy = trimesh.load_mesh(object_path)
+mesh_Oy.apply_scale(object_scale)
+
+# %%
+# Compute object transform
+X_N_Oy = np.eye(4)
+bounds = mesh_Oy.bounds
+assert bounds.shape == (2, 3)
+min_y = bounds[0, 1]
+X_N_Oy[1, 3] = -min_y
+
+X_Oy_N = np.linalg.inv(X_N_Oy)
+
+# Transform mesh to nerf frame
+mesh_N = mesh_Oy.copy()
+mesh_N.apply_transform(X_N_Oy)
+
+# %%
+# Extract density info
+N_FINGERS = 4
+grasp_frame_transforms = file["/grasp_transforms"][GRASP_IDX]
+assert grasp_frame_transforms.shape == (N_FINGERS, 4, 4)
+nerf_densities = file["/nerf_densities"][GRASP_IDX]
+assert len(nerf_densities.shape) == 4
+
+T_Oy_Fi = pp.from_matrix(torch.from_numpy(grasp_frame_transforms), pp.SE3_type)
+assert T_Oy_Fi.lshape == (N_FINGERS,)
+
+T_N_Oy = pp.from_matrix(
+    torch.from_numpy(X_N_Oy)
+    .float()
+    .unsqueeze(dim=0)
+    .repeat_interleave(N_FINGERS, dim=0)
+    .reshape(N_FINGERS, 4, 4),
+    pp.SE3_type,
+).to(T_Oy_Fi.device)
+
+# Transform grasp_frame_transforms to nerf frame
+T_N_Fi = T_N_Oy @ T_Oy_Fi
+
+# Generate RaySamples.
+fingertip_config = EvenlySpacedFingertipConfig()
+delta = fingertip_config.grasp_depth_mm / 1000 / (fingertip_config.num_pts_z - 1)
+
+nerf_alphas = 1 - np.exp(-delta * nerf_densities)
+
+ray_origins_finger_frame = grasp_utils.get_ray_origins_finger_frame(fingertip_config)
+ray_samples = grasp_utils.get_ray_samples(
+    ray_origins_finger_frame,
+    T_N_Fi,
+    fingertip_config,
+)
+
+query_points_N = ray_samples.frustums.get_positions().reshape(
+    N_FINGERS,
+    fingertip_config.num_pts_x,
+    fingertip_config.num_pts_y,
+    fingertip_config.num_pts_z,
+    3,
+)
+query_points_Oy = query_points_N + X_Oy_N[:3, 3].reshape(1, 1, 1, 1, 3)
+
+flatten_query_points_Oy = query_points_Oy.reshape(-1, 3)
+flatten_nerf_alphas = nerf_alphas.flatten()
+
+# %%
+# Extract density global info
+nerf_densities_global_idx = file["/nerf_densities_global_idx"][GRASP_IDX]
+nerf_densities_global = file["/nerf_densities_global"][nerf_densities_global_idx]
+assert len(nerf_densities_global.shape) == 3
+
+nerf_alphas_global = 1 - np.exp(-delta * nerf_densities_global)
+
+xx, yy, zz = np.meshgrid(
+    np.linspace(-0.2, 0.2, nerf_densities_global.shape[0]),
+    np.linspace(-0.2, 0.2, nerf_densities_global.shape[1]),
+    np.linspace(-0.2, 0.2, nerf_densities_global.shape[2]),
+    indexing="ij",
+)
+query_points_global_Oy = np.stack([xx, yy, zz], axis=-1)
+assert query_points_global_Oy.shape == nerf_densities_global.shape + (3,)
+
+flatten_query_points_global_Oy = query_points_global_Oy.reshape(-1, 3)
+flatten_nerf_alphas_global = nerf_alphas_global.flatten()
+
+# %%
+# Extract labels
+passed_eval = file["/passed_eval"][GRASP_IDX]
+passed_simulation = file["/passed_simulation"][GRASP_IDX]
+passed_penetration_threshold = file["/passed_penetration_threshold"][GRASP_IDX]
+
+# %%
+# Plot
+fig = go.Figure()
+fig.add_trace(
+    go.Mesh3d(
+        x=mesh_Oy.vertices[:, 0],
+        y=mesh_Oy.vertices[:, 1],
+        z=mesh_Oy.vertices[:, 2],
+        i=mesh_Oy.faces[:, 0],
+        j=mesh_Oy.faces[:, 1],
+        k=mesh_Oy.faces[:, 2],
+        opacity=0.5,
+    )
+)
+for i in range(N_FINGERS):
+    fig.add_trace(
+        go.Scatter3d(
+            x=flatten_query_points_Oy[:, 0],
+            y=flatten_query_points_Oy[:, 1],
+            z=flatten_query_points_Oy[:, 2],
+            mode="markers",
+            marker=dict(
+                size=2,
+                color=flatten_nerf_alphas,
+                # colorbar=dict(title="Density"),
+            ),
+            name=f"Query Points Finger {i}",
+        )
+    )
+density_threshold = 0.01
+fig.add_trace(
+    go.Scatter3d(
+        x=flatten_query_points_global_Oy[:, 0][
+            flatten_nerf_alphas_global > density_threshold
+        ],
+        y=flatten_query_points_global_Oy[:, 1][
+            flatten_nerf_alphas_global > density_threshold
+        ],
+        z=flatten_query_points_global_Oy[:, 2][
+            flatten_nerf_alphas_global > density_threshold
+        ],
+        mode="markers",
+        marker=dict(
+            size=2,
+            color=flatten_nerf_alphas_global[
+                flatten_nerf_alphas_global > density_threshold
+            ],
+            # colorbar=dict(title="Density"),
+        ),
+        name="Query Points Global",
+    )
+)
+fig.update_layout(scene_aspectmode="data", title_text=f"{object_code}_{object_scale}_{GRASP_IDX}_{passed_eval}_{passed_simulation}_{passed_penetration_threshold}")
+
+fig.show()
+
+
+# %%
+file.keys()
+
+# %%


### PR DESCRIPTION
Changes:
* Add cnn-3d-xyz-global-cnn and cnn-3d-xyz-global-mlp
* Add hardcoded paths for nerf configs for create data
* Add in nerf_densities_global_config with hardcoded config params, then integrate it to store in Create dataset script
* Address the N != Oy frame issue in the Create dataset script
* Comment out big gpu memory prints
* Fix up some vis utils, transform utils, densities in grid, etc.
* Integrate nerf_densities_global into the BatchInputData, integrate augmented coords
* Try to ensure backwards compatible
* Get nerf_densities_global at grasp metric inference time if needed
* warmup=False for main() of run_pipeline and run_frogger_pipeline
* Add debug dataset script